### PR TITLE
Add async iterable event listener

### DIFF
--- a/packages/frame-core/src/base/GlobalEmitter.ts
+++ b/packages/frame-core/src/base/GlobalEmitter.ts
@@ -18,12 +18,12 @@ export class GlobalEmitter<TEvent extends ManagedEvent> extends ManagedObject {
 	 */
 	override listen(
 		handler: (this: unknown, event: TEvent) => void | Promise<void>,
-	): this;
+	): void;
 	override listen(): AsyncIterable<TEvent>;
 	override listen(
 		handler?: (this: unknown, event: TEvent) => void | Promise<void>,
-	): this | AsyncIterable<ManagedEvent> {
-		return super.listen(handler as any);
+	) {
+		return super.listen(handler as any) as any;
 	}
 
 	/** Strongly typed version of {@link ManagedObject.emit()} */

--- a/packages/frame-core/src/base/GlobalEmitter.ts
+++ b/packages/frame-core/src/base/GlobalEmitter.ts
@@ -14,11 +14,15 @@ import { hasTraps, $_traps_event } from "./object_util.js";
 export class GlobalEmitter<TEvent extends ManagedEvent> extends ManagedObject {
 	/**
 	 * Adds a (permanent) event listener
-	 * @param handler A function that will be called for every event that's emitted, with the event as the only argument
+	 * @param handler A function that will be called for every event that's emitted, with the event as the only argument; if not provided, this method returns an async iterable (see {@link ManagedObject.listen()}
 	 */
 	override listen(
 		handler: (this: unknown, event: TEvent) => void | Promise<void>,
-	): this {
+	): this;
+	override listen(): AsyncIterable<TEvent>;
+	override listen(
+		handler?: (this: unknown, event: TEvent) => void | Promise<void>,
+	): this | AsyncIterable<ManagedEvent> {
 		return super.listen(handler as any);
 	}
 

--- a/packages/frame-core/src/base/ManagedObject.ts
+++ b/packages/frame-core/src/base/ManagedObject.ts
@@ -130,14 +130,95 @@ export class ManagedObject {
 
 	/**
 	 * Adds a handler for all events emitted by this object
-	 * @note This method adds a permanent listener. To prevent memory leaks, it may be better to use an {@link Observer} that can be stopped when needed.
+	 *
 	 * @param handler A function (void return type, or asynchronous) that will be called for all events emitted by this object; the function is called with the `this` value set to the managed object, and a single event argument
+	 * @returns The managed object itself, or an async iterable if no callback function is provided
+	 *
+	 * @description
+	 * This method adds a permanent listener for all events emitted by this object, in one of two ways. Either a callback function can be provided, or this method returns an async iterable that can be used to iterate over all events.
+	 *
+	 * **Callback function** — If a callback function is provided, it will be called for every event that's emitted by this object. The function is called with the `this` value set to the managed object, and a single event argument. The callback function can be asynchronous, in which case the result is awaited to catch any errors.
+	 *
+	 * **Async iterable** — If no callback function is provided, this method returns an async iterable that can be used to iterate over all events using a `for await...of` loop. The loop body is run for each event, in the order they're emitted, either awaiting new events or continuing execution immediately. The loop stops when the object is unlinked.
+	 *
+	 * @note This method adds a permanent listener. To prevent memory leaks, it may be better to use an {@link Observer} that can be stopped when needed, if the object is expected to outlive the listener.
+	 *
+	 * @example
+	 * // Handle all events using a callback function
+	 * someObject.listen((event) => {
+	 *   if (event.name === "Foo") {
+	 *     // ...handle Foo event
+	 *   }
+	 * });
+	 * // ... (code continues to run)
+	 *
+	 * @example
+	 * // Handle all events using an async iterable
+	 * for await (let event of someObject.listen()) {
+	 *   if (event.name === "Foo") {
+	 *     // ...handle Foo event
+	 *   }
+	 * }
+	 * // ... (code here runs after object is unlinked, or `break`)
 	 */
-	listen(handler: (this: this, event: ManagedEvent) => Promise<void> | void) {
-		addTrap(this, $_traps_event, (target, p, event) => {
-			handler.call(this, event)?.catch?.(errorHandler);
-		});
-		return this;
+	listen(
+		handler: (this: this, event: ManagedEvent) => Promise<void> | void,
+	): this;
+	listen(): AsyncIterable<ManagedEvent>;
+	listen(handler?: (this: this, event: ManagedEvent) => Promise<void> | void) {
+		// add a single handler if provided
+		if (handler) {
+			addTrap(this, $_traps_event, (target, p, event) => {
+				handler.call(this, event)?.catch?.(errorHandler);
+			});
+			return this;
+		}
+
+		// return an async iterable for events
+		let self = this;
+		let iterable: AsyncIterable<ManagedEvent> = {
+			[Symbol.asyncIterator]() {
+				let buf: ManagedEvent[] | undefined = [];
+				let waiter: undefined | ((event?: ManagedEvent) => void);
+				addTrap(
+					self,
+					$_traps_event,
+					(target, p, event) => {
+						// handle an event: add to buffer, or resolve a waiter
+						if (waiter) waiter(event);
+						else if (buf) buf.push(event);
+					},
+					() => {
+						// handle unlinking: resolve waiter if any
+						if (waiter) waiter();
+					},
+				);
+				const stop = (): any => {
+					buf = undefined;
+					return Promise.resolve({ done: true });
+				};
+
+				// return the iterator
+				let iterator: AsyncIterator<ManagedEvent> = {
+					async next() {
+						if (!buf) return { done: true } as any;
+						if (buf.length) return { value: buf.shift()! };
+						return new Promise<IteratorResult<ManagedEvent>>((resolve) => {
+							if (self[$_unlinked]) return resolve(stop());
+							waiter = (event) => {
+								waiter = undefined;
+								if (self[$_unlinked]) resolve({ done: true } as any);
+								else resolve({ value: event! });
+							};
+						});
+					},
+					return: stop,
+					throw: stop,
+				};
+				return iterator;
+			},
+		};
+		return iterable;
 	}
 
 	/** Returns true if the object has been unlinked */

--- a/packages/frame-core/src/base/ManagedObject.ts
+++ b/packages/frame-core/src/base/ManagedObject.ts
@@ -132,7 +132,7 @@ export class ManagedObject {
 	 * Adds a handler for all events emitted by this object
 	 *
 	 * @param handler A function (void return type, or asynchronous) that will be called for all events emitted by this object; the function is called with the `this` value set to the managed object, and a single event argument
-	 * @returns The managed object itself, or an async iterable if no callback function is provided
+	 * @returns If no callback function is provided, an async iterable that can be used instead
 	 *
 	 * @description
 	 * This method adds a permanent listener for all events emitted by this object, in one of two ways. Either a callback function can be provided, or this method returns an async iterable that can be used to iterate over all events.
@@ -163,7 +163,7 @@ export class ManagedObject {
 	 */
 	listen(
 		handler: (this: this, event: ManagedEvent) => Promise<void> | void,
-	): this;
+	): void;
 	listen(): AsyncIterable<ManagedEvent>;
 	listen(handler?: (this: this, event: ManagedEvent) => Promise<void> | void) {
 		// add a single handler if provided
@@ -171,7 +171,7 @@ export class ManagedObject {
 			addTrap(this, $_traps_event, (target, p, event) => {
 				handler.call(this, event)?.catch?.(errorHandler);
 			});
-			return this;
+			return;
 		}
 
 		// return an async iterable for events


### PR DESCRIPTION
This PR adds a variant to the `ManagedObject.listen()` method. When called without a listener function, the result is an async iterable that can be used with `for await (...)` loops.

The intention is to be able to use this with e.g. dialog activities, that are activated and can then be awaited for events until they are unlinked (or unlinked when an event occurs, like confirming input).