### PR TITLE
Attach method and binding revisions

### DIFF
--- a/packages/frame-core/src/app/ActivationContext.ts
+++ b/packages/frame-core/src/app/ActivationContext.ts
@@ -11,7 +11,7 @@ export class ActivationContext extends ManagedObject {
 	/** Creates a new instance of this class; do not use */
 	constructor() {
 		super();
-		this.observeAttach("activationPath");
+		this.autoAttach("activationPath");
 	}
 
 	/**

--- a/packages/frame-core/src/app/Activity.ts
+++ b/packages/frame-core/src/app/Activity.ts
@@ -1,13 +1,14 @@
 import {
+	Binding,
 	bound,
 	ConfigOptions,
 	ManagedObject,
 	Observer,
 	StringConvertible,
 } from "../base/index.js";
-import { NavigationTarget } from "./NavigationTarget.js";
-import { ActivationPath } from "./ActivationPath.js";
 import { err, ERROR } from "../errors.js";
+import { ActivationPath } from "./ActivationPath.js";
+import { NavigationTarget } from "./NavigationTarget.js";
 import { AsyncTaskQueue } from "./Scheduler.js";
 
 const _boundActivationPath = bound("activationPath");
@@ -65,6 +66,7 @@ export class Activity extends ManagedObject {
 	 */
 	constructor() {
 		super();
+		Binding.limitTo(this);
 		_boundActivationPath.bindTo(this, "activationPath");
 
 		// create observer to match path and activate/deactivate

--- a/packages/frame-core/src/app/GlobalContext.ts
+++ b/packages/frame-core/src/app/GlobalContext.ts
@@ -35,9 +35,9 @@ export class GlobalContext extends ManagedObject {
 	private constructor() {
 		if (GlobalContext.instance) throw Error;
 		super();
-		this.observeAttach("services");
-		this.observeAttach("activities");
-		this.observeAttach("renderer");
+		this.autoAttach("services");
+		this.autoAttach("activities");
+		this.autoAttach("renderer");
 
 		// define i18n property and handle new objects when set
 		let i18n: I18nProvider | undefined;

--- a/packages/frame-core/src/app/Service.ts
+++ b/packages/frame-core/src/app/Service.ts
@@ -1,4 +1,4 @@
-import { ManagedObject } from "../base/ManagedObject.js";
+import { Binding, ManagedObject } from "../base/index.js";
 import { ServiceContext } from "./ServiceContext.js";
 
 /**
@@ -12,6 +12,11 @@ import { ServiceContext } from "./ServiceContext.js";
  * @see {@link ServiceContext}
  */
 export abstract class Service extends ManagedObject {
+	constructor() {
+		super();
+		Binding.limitTo(this);
+	}
+
 	/** Returns true if this service is currently registered */
 	isServiceRegistered() {
 		// use duck typing to find out if parent map is a ServiceContext

--- a/packages/frame-core/src/app/ViewActivity.ts
+++ b/packages/frame-core/src/app/ViewActivity.ts
@@ -1,9 +1,10 @@
 import { bound, ManagedEvent, ManagedObject, Observer } from "../base/index.js";
 import { errorHandler } from "../errors.js";
+import type { UIFormContext } from "../ui/UIFormContext.js";
 import { Activity } from "./Activity.js";
 import { app } from "./GlobalContext.js";
-import { NavigationTarget } from "./NavigationTarget.js";
-import { RenderContext } from "./RenderContext.js";
+import type { NavigationTarget } from "./NavigationTarget.js";
+import type { RenderContext } from "./RenderContext.js";
 import { View, ViewClass } from "./View.js";
 
 const _boundRenderer = bound("renderer");
@@ -131,6 +132,9 @@ export class ViewActivity extends Activity implements RenderContext.Renderable {
 
 	/** Placement options for root view output */
 	renderPlacement?: RenderContext.PlacementOptions = undefined;
+
+	/** Default form context used with input elements, if any */
+	formContext?: UIFormContext = undefined;
 
 	/**
 	 * Searches the view hierarchy for view objects of the provided type

--- a/packages/frame-core/src/app/ViewActivity.ts
+++ b/packages/frame-core/src/app/ViewActivity.ts
@@ -95,7 +95,7 @@ export class ViewActivity extends Activity implements RenderContext.Renderable {
 				}
 			}
 		}
-		this.observeAttach("view", new ViewObserver(this));
+		this.autoAttach("view", new ViewObserver(this));
 
 		// observe properties (async) to render/remove automatically
 		class ViewActivityObserver extends Observer<ViewActivity> {

--- a/packages/frame-core/src/app/ViewComposite.ts
+++ b/packages/frame-core/src/app/ViewComposite.ts
@@ -11,7 +11,7 @@ import { View, ViewClass } from "./View.js";
  *
  * The encapsulated view is referenced by the {@link ViewComposite.body body} property, which is usually set automatically, either when the ViewComposite is instantiated or right before rendering. It may be changed or unlinked at any time; the rendered view will be updated accordingly by the ViewComposite itself.
  *
- * The {@link ViewComposite.body body} property is watched using {@link ManagedObject.observeAttach}, which means that setting it to a view instance automatically attaches the object to the ViewComposite. Setting the property to undefined will unlink the existing view, and setting it to a new view will unlink an existing one. Therefore, the ViewComposite instance can only contain a single view object at a time.
+ * The {@link ViewComposite.body body} property is watched using {@link ManagedObject.autoAttach}, which means that setting it to a view instance automatically attaches the object to the ViewComposite. Setting the property to undefined will unlink the existing view, and setting it to a new view will unlink an existing one. Therefore, the ViewComposite instance can only contain a single view object at a time.
  *
  * Since the view is attached to the ViewComposite object, bindings continue to work, and events can be handled either by the ViewComposite object or by a containing object.
  *
@@ -222,7 +222,7 @@ export abstract class ViewComposite extends View {
 				}
 			}
 		}
-		this.observeAttach("body", new ViewObserver(this));
+		this.autoAttach("body", new ViewObserver(this));
 	}
 
 	/**

--- a/packages/frame-core/src/base/ManagedEvent.ts
+++ b/packages/frame-core/src/base/ManagedEvent.ts
@@ -4,7 +4,7 @@ import type { ManagedObject } from "./ManagedObject.js";
  * An object that represents an event, to be emitted on a {@link ManagedObject}
  *
  * @description
- * Events can be emitted on instances of {@link ManagedObject}, and handled using {@link ManagedObject.listen()}, {@link Observer}, or a change callback to {@link ManagedObject.attach()} or {@link ManagedObject.observeAttach()}.
+ * Events can be emitted on instances of {@link ManagedObject}, and handled using {@link ManagedObject.listen()}, {@link Observer}, or a change callback to {@link ManagedObject.attach()} or {@link ManagedObject.autoAttach()}.
  *
  * In most cases, instances of ManagedEvent are created by {@link ManagedObject.emit()} itself, when provided with just the event name and data (if any). When handling events, the implicitly created ManagedEvent will be passed to the handler.
  *
@@ -29,7 +29,7 @@ import type { ManagedObject } from "./ManagedObject.js";
  * class MyObject extends ManagedObject {
  *   constructor() {
  *     super();
- *     this.observeAttach("foo", (foo, e) => {
+ *     this.autoAttach("foo", (foo, e) => {
  *       // ...either foo property is set directly, OR
  *       // a change event `e` was emitted
  *     })
@@ -105,7 +105,7 @@ export class ManagedEvent<
 /**
  * An object that represents an event, emitted on a {@link ManagedObject} when its internal state changes
  * - Events of this type can be emitted using the {@link ManagedObject.emitChange()} method.
- * - Change events are handled specially by {@link Observer}, and trigger the callback provided to {@link ManagedObject.attach()} and {@link ManagedObject.observeAttach()}.
+ * - Change events are handled specially by {@link Observer}, and trigger the callback provided to {@link ManagedObject.attach()} and {@link ManagedObject.autoAttach()}.
  */
 export class ManagedChangeEvent<
 	TSource extends ManagedObject = ManagedObject,

--- a/packages/frame-core/src/base/ManagedList.ts
+++ b/packages/frame-core/src/base/ManagedList.ts
@@ -71,9 +71,9 @@ class ManagedListIterator<T extends ManagedObject> implements Iterator<T> {
  *
  * Managed lists are used in many places throughout the framework, such as to reference view objects within a {@link UIContainer} object. Managed lists can also be used by application code to efficiently represent lists of data models or other records.
  *
- * **Attaching list items** — By default, objects aren't attached to the list, so they could be attached to other objects themselves and still be part of a managed list. However, you can enable auto-attaching of objects in a list using the {@link ManagedList.autoAttach()} method — **or** by attaching the list itself to another object. This ensures that objects in a list are only attached to the list itself, and are unlinked when they're removed from the list (and removed from the list when they're no longer attached to it, e.g. when moved to another auto-attaching list).
+ * **Attaching list items** — By default, objects aren't attached to the list, so they could be attached to other objects themselves and still be part of a managed list. However, you can enable auto-attaching of objects in a list using the {@link ManagedList.attachAll()} method — **or** by attaching the list itself to another object. This ensures that objects in a list are only attached to the list itself, and are unlinked when they're removed from the list (and removed from the list when they're no longer attached to it, e.g. when moved to another auto-attaching list).
  *
- * **Events** — Since ManagedList itself inherits from ManagedObject, a list can emit events, too. When any objects are added, moved, or removed, a {@link ManagedList.ChangeEvent} is emitted. In addition, for auto-attaching lists (see {@link ManagedList.autoAttach()}) any events that are emitted by an object are re-emitted on the list itself. The {@link ManagedEvent.source} property can be used to find the object that originally emitted the event.
+ * **Events** — Since ManagedList itself inherits from ManagedObject, a list can emit events, too. When any objects are added, moved, or removed, a {@link ManagedList.ChangeEvent} is emitted. In addition, for auto-attaching lists (see {@link ManagedList.attachAll()}) any events that are emitted by an object are re-emitted on the list itself. The {@link ManagedEvent.source} property can be used to find the object that originally emitted the event.
  *
  * **Nested lists** — Managed lists can contain (and even attach to) other managed lists, which allows for building nested or recursive data structures that fully support bindings and events.
  *
@@ -111,7 +111,7 @@ export class ManagedList<
 			this,
 			$_origin,
 			(t, p, v) => {
-				if (v && this._attach === undefined) this.autoAttach(true);
+				if (v && this._attach === undefined) this.attachAll(true);
 			},
 			() => {
 				// ... and clear the list when unlinked
@@ -604,7 +604,7 @@ export class ManagedList<
 	 *
 	 * @error This method throws an error if the feature can't be enabled or disabled.
 	 */
-	autoAttach(set: boolean, noEventPropagation?: boolean) {
+	attachAll(set: boolean, noEventPropagation?: boolean) {
 		// set property to false ONLY if no attached objects
 		if (!set && this._attach && this[$_list].map.size) {
 			throw err(ERROR.List_AttachState);
@@ -631,7 +631,7 @@ export class ManagedList<
 		attachObject(this, target, new AttachObserver(this, !this._noPropagation));
 	}
 
-	/** True if objects should be attached to this map when added (and no duplicates allowed) */
+	/** True if objects should be attached to this list when added (and no duplicates allowed) */
 	private _attach?: boolean;
 
 	/** True if attached object events should NOT be propagated */

--- a/packages/frame-core/src/base/ManagedObject.ts
+++ b/packages/frame-core/src/base/ManagedObject.ts
@@ -8,6 +8,7 @@ import {
 	attachObject,
 	watchAttachProperty,
 	addTrap,
+	$_bindFilter,
 } from "./object_util.js";
 import { ManagedEvent, ManagedChangeEvent } from "./ManagedEvent.js";
 import { Observer } from "./Observer.js";
@@ -95,6 +96,9 @@ export class ManagedObject {
 
 	/** @internal Reference to origin (parent) managed object, if any */
 	declare [$_origin]?: ManagedObject;
+
+	/** @internal A function that's used to filter applicable bindings on this object */
+	declare [$_bindFilter]?: (property: string | symbol) => boolean;
 
 	/** @internal Property getter for non-observable property bindings, overridden on managed lists */
 	[$_get](propertyName: string) {

--- a/packages/frame-core/src/base/ManagedObject.ts
+++ b/packages/frame-core/src/base/ManagedObject.ts
@@ -32,7 +32,7 @@ export function isManagedObject(object: any): object is ManagedObject {
  * **Attaching objects** — Managed objects are meant to be linked together to form a _directed graph_, i.e. a tree structure where one object can be 'attached' to only one other managed object: its parent, origin, or containing object. In turn, several objects can be attached to every object, which makes up a hierarchical structure.
  *
  * - Objects can be attached ad-hoc using the {@link ManagedObject.attach attach()} method. An {@link Observer} or callback function can be used to listen for events (see below) or wait for the object to be unlinked.
- * - Objects can be attached by referencing them from specific observed properties. The property needs to be watched using the {@link ManagedObject.observeAttach observeAttach()} method; afterwards, any object assigned to this property is attached automatically, and then when the referenced object is unlinked, the property is set to undefined. The {@link ManagedObject.observeAttach observeAttach()} method also accepts an observer or callback function.
+ * - Objects can be attached by referencing them from specific observed properties. The property needs to be watched using the {@link ManagedObject.autoAttach autoAttach()} method; afterwards, any object assigned to this property is attached automatically, and then when the referenced object is unlinked, the property is set to undefined. The {@link ManagedObject.autoAttach autoAttach()} method also accepts an observer or callback function.
  * - When an object is unlinked, its attached objects are unlinked as well.
  *
  * **Events** — The {@link ManagedObject.emit emit()} method 'emits' an event from a managed object. Events are instances of {@link ManagedEvent}, which can be handled using a callback provided to the {@link ManagedObject.listen listen()} method, or an {@link Observer} that's currently observing the object. Typically, objects are observed by their parent object (the object they're attached to). This enables event _propagation_, where events emitted by an object such as a {@link UIButton} are handled by a managed object further up the tree — such as a {@link ViewActivity}. Refer to {@link ManagedEvent} for details.
@@ -120,7 +120,7 @@ export class ManagedObject {
 	/**
 	 * Emits a change event, an instance of {@link ManagedChangeEvent}
 	 * - Events can be handled using {@link ManagedObject.listen()} or an {@link Observer}. Refer to {@link ManagedEvent} for details.
-	 * - Change events are treated differently, e.g. change events are also handled using the callback passed to {@link ManagedObject.attach attach()} and {@link ManagedObject.observeAttach observeAttach()}, and trigger updates of bound (sub) property values.
+	 * - Change events are treated differently, e.g. change events are also handled using the callback passed to {@link ManagedObject.attach attach()} and {@link ManagedObject.autoAttach autoAttach()}, and trigger updates of bound (sub) property values.
 	 * @param name An event name; an instance of ManagedChangeEvent with the provided name will be created by this method
 	 * @param data Additional data to be set on {@link ManagedEvent.data}
 	 */
@@ -230,8 +230,8 @@ export class ManagedObject {
 	 * Unlinks this managed object
 	 * @summary This method marks the object as 'stale' or 'deleted', which means that the object should no longer be used by the application — even though the object's properties can still be accessed.
 	 *
-	 * - Any objects that have been attached to the unlinked object (using {@link ManagedObject.attach attach()} or {@link ManagedObject.observeAttach observeAttach()}) will also be unlinked.
-	 * - If this object is attached using {@link ManagedObject.observeAttach observeAttach()} (to a 'parent' or containing object), the corresponding property will be set to undefined.
+	 * - Any objects that have been attached to the unlinked object (using {@link ManagedObject.attach attach()} or {@link ManagedObject.autoAttach autoAttach()}) will also be unlinked.
+	 * - If this object is attached using {@link ManagedObject.autoAttach autoAttach()} (to a 'parent' or containing object), the corresponding property will be set to undefined.
 	 * - If this object was attached to a containing {@link ManagedList}, the item will be removed.
 	 */
 	unlink() {
@@ -294,7 +294,7 @@ export class ManagedObject {
 	 * class ParentObject extends ManagedObject {
 	 *   constructor() {
 	 *     super();
-	 *     this.observeAttach(
+	 *     this.autoAttach(
 	 *       "target",
 	 *       (target, event) => {
 	 *         // ...target is either the target object, or undefined
@@ -310,7 +310,7 @@ export class ManagedObject {
 	 * parent.target.unlink();
 	 * parent.target // => undefined
 	 */
-	protected observeAttach<
+	protected autoAttach<
 		K extends keyof this,
 		T extends NonNullable<this[K]> & ManagedObject,
 	>(
@@ -329,7 +329,7 @@ export namespace ManagedObject {
 		new (...args: any[]): T;
 	};
 
-	/** Type definition for the callback function argument passed to {@link ManagedObject.attach()} and {@link ManagedObject.observeAttach()} */
+	/** Type definition for the callback function argument passed to {@link ManagedObject.attach()} and {@link ManagedObject.autoAttach()} */
 	export type AttachObserverFunction<T extends ManagedObject> = (
 		target?: T,
 		event?: ManagedChangeEvent<T>,

--- a/packages/frame-core/src/base/Observer.ts
+++ b/packages/frame-core/src/base/Observer.ts
@@ -34,7 +34,7 @@ const _nextTick = Promise.resolve();
  *
  * Before any property can be observed, the `observeProperty*()` method must be called. This should be done within the {@link Observer.observe observe()} method, which must be overridden. Refer to the examples below.
  *
- * Observers can be created manually (using `new`, and the {@link Observer.observe observe()} method), but they can also be passed to {@link ManagedObject.attach()} and {@link ManagedObject.observeAttach()} to observe attached objects. Refer to the examples below.
+ * Observers can be created manually (using `new`, and the {@link Observer.observe observe()} method), but they can also be passed to {@link ManagedObject.attach()} and {@link ManagedObject.autoAttach()} to observe attached objects. Refer to the examples below.
  *
  * The observer is automatically stopped when the target is unlinked, but it can also be stopped manually (see {@link Observer.stop stop()}). This may be necessary to avoid memory leaks, since observers are linked to the observed object while they're active — keeping them (and any referenced objects) from being freed up by the JavaScript garbage collector as long as the observed object is referenced itself.
  *
@@ -44,7 +44,7 @@ export class Observer<T extends ManagedObject = ManagedObject> {
 	/**
 	 * Creates a new observer, without observing any object yet
 	 * - Start observing an object using the {@link Observer.observe observe()} method; override this method to add property observers.
-	 * - Alternatively, pass an observer class to {@link ManagedObject.attach()} or {@link ManagedObject.observeAttach()}.
+	 * - Alternatively, pass an observer class to {@link ManagedObject.attach()} or {@link ManagedObject.autoAttach()}.
 	 */
 	constructor() {
 		Object.defineProperty(this, $_observed, {

--- a/packages/frame-core/test/tests/app/activation.ts
+++ b/packages/frame-core/test/tests/app/activation.ts
@@ -100,7 +100,7 @@ describe("ActivationPath and ActivationContext", () => {
 			class MyActivity extends Activity {
 				constructor() {
 					super();
-					this.observeAttach("child");
+					this.autoAttach("child");
 				}
 				child?: MyActivity;
 			}
@@ -116,7 +116,7 @@ describe("ActivationPath and ActivationContext", () => {
 			class MyActivity extends Activity {
 				constructor() {
 					super();
-					this.observeAttach("child");
+					this.autoAttach("child");
 				}
 				child?: MyActivity;
 			}

--- a/packages/frame-core/test/tests/app/navigationtarget.ts
+++ b/packages/frame-core/test/tests/app/navigationtarget.ts
@@ -77,7 +77,7 @@ describe("NavigationTarget", () => {
 		class MyActivity extends Activity {
 			constructor() {
 				super();
-				this.observeAttach("nested");
+				this.autoAttach("nested");
 			}
 			nested?: MyActivity;
 		}

--- a/packages/frame-core/test/tests/base/bindings.ts
+++ b/packages/frame-core/test/tests/base/bindings.ts
@@ -65,8 +65,8 @@ describe("Bindings", () => {
 					super();
 
 					// add auto-attached properties
-					this.observeAttach("other");
-					this.observeAttach("child");
+					this.autoAttach("other");
+					this.autoAttach("child");
 
 					// add mechanics for dynamic property x
 					let x = 0;
@@ -96,7 +96,7 @@ describe("Bindings", () => {
 			class ChildObject extends ManagedObject {
 				constructor() {
 					super();
-					this.observeAttach("nested");
+					this.autoAttach("nested");
 				}
 				aa?: number;
 				dd?: number;
@@ -451,11 +451,11 @@ describe("Bindings", () => {
 			class BaseObject extends ManagedObject {
 				constructor() {
 					super();
-					this.observeAttach("nest");
+					this.autoAttach("nest");
 					for (let i = 0; i < 26; i++) {
 						let letter = String.fromCharCode("a".charCodeAt(0) + i);
 						(this as any)[letter] = new AnotherObject();
-						this.observeAttach(letter as any);
+						this.autoAttach(letter as any);
 					}
 				}
 				declare nest: BaseObject;

--- a/packages/frame-core/test/tests/base/events.ts
+++ b/packages/frame-core/test/tests/base/events.ts
@@ -88,7 +88,7 @@ describe("Events", () => {
 		});
 	});
 
-	describe.only("Async iterator listeners", () => {
+	describe("Async iterator listeners", () => {
 		test("Unlink cancels iterator", async (t) => {
 			let c = new ManagedObject();
 			let iter = c.listen()[Symbol.asyncIterator]();

--- a/packages/frame-core/test/tests/base/managedlist.ts
+++ b/packages/frame-core/test/tests/base/managedlist.ts
@@ -530,7 +530,7 @@ describe("ManagedList", () => {
 			let a = new NamedObject("a");
 			let list = new ManagedList(a);
 			expect(ManagedObject.whence(a)).toBeUndefined();
-			let parent = new ManagedList().autoAttach(true);
+			let parent = new ManagedList().attachAll(true);
 			parent.add(list);
 			expect(ManagedObject.whence(list)).toBe(parent);
 			expect(ManagedObject.whence(a)).toBe(list);
@@ -540,11 +540,11 @@ describe("ManagedList", () => {
 		});
 
 		test("Override auto attach", () => {
-			let list = new ManagedList().autoAttach(false);
+			let list = new ManagedList().attachAll(false);
 			let a = new NamedObject("a");
 			list.add(a);
 			expect(ManagedObject.whence(a)).toBeUndefined();
-			let parent = new ManagedList().autoAttach(true);
+			let parent = new ManagedList().attachAll(true);
 			parent.add(list);
 			expect(ManagedObject.whence(list)).toBe(parent);
 			expect(ManagedObject.whence(a)).toBeUndefined();
@@ -556,13 +556,13 @@ describe("ManagedList", () => {
 		test("Can't override with existing objects", () => {
 			let a = new NamedObject("a");
 			let list = new ManagedList(a);
-			let parent = new ManagedList().autoAttach(true);
+			let parent = new ManagedList().attachAll(true);
 			parent.add(list);
-			expect(() => list.autoAttach(false)).toThrowError();
+			expect(() => list.attachAll(false)).toThrowError();
 		});
 
 		test("Attached objects, before adding", () => {
-			let list = new ManagedList().autoAttach(true);
+			let list = new ManagedList().attachAll(true);
 			let a = new NamedObject("a");
 			list.add(a);
 			expect(ManagedObject.whence(a)).toBe(list);
@@ -570,48 +570,48 @@ describe("ManagedList", () => {
 
 		test("Attached objects, after adding", () => {
 			let a = new NamedObject("a");
-			let list = new ManagedList(a).autoAttach(true);
+			let list = new ManagedList(a).attachAll(true);
 			expect(ManagedObject.whence(a)).toBe(list);
 		});
 
 		test("Attached objects are unlinked when removed: remove", () => {
 			let a = new NamedObject("a");
-			let list = new ManagedList(a).autoAttach(true);
+			let list = new ManagedList(a).attachAll(true);
 			list.remove(a);
 			expect(a.isUnlinked()).toBeTruthy();
 		});
 
 		test("Attached objects are unlinked when removed: clear", () => {
 			let a = new NamedObject("a");
-			let list = new ManagedList(a).autoAttach(true);
+			let list = new ManagedList(a).attachAll(true);
 			list.clear();
 			expect(a.isUnlinked()).toBeTruthy();
 		});
 
 		test("Attached objects are unlinked when removed: unlink", () => {
 			let a = new NamedObject("a");
-			let list = new ManagedList(a).autoAttach(true);
+			let list = new ManagedList(a).attachAll(true);
 			list.unlink();
 			expect(a.isUnlinked()).toBeTruthy();
 		});
 
 		test("Objects aren't unlinked when not attached: remove", () => {
 			let a = new NamedObject("a");
-			let list = new ManagedList(a).autoAttach(false);
+			let list = new ManagedList(a).attachAll(false);
 			list.remove(a);
 			expect(a.isUnlinked()).toBeFalsy();
 		});
 
 		test("Objects aren't unlinked when not attached: clear", () => {
 			let a = new NamedObject("a");
-			let list = new ManagedList(a).autoAttach(false);
+			let list = new ManagedList(a).attachAll(false);
 			list.clear();
 			expect(a.isUnlinked()).toBeFalsy();
 		});
 
 		test("Objects aren't unlinked when not attached: unlink", () => {
 			let a = new NamedObject("a");
-			let list = new ManagedList(a).autoAttach(false);
+			let list = new ManagedList(a).attachAll(false);
 			list.unlink();
 			expect(a.isUnlinked()).toBeFalsy();
 		});
@@ -619,7 +619,7 @@ describe("ManagedList", () => {
 		test("Attached objects are moved using replace", () => {
 			let a = new NamedObject("a");
 			let b = new NamedObject("b");
-			let list = new ManagedList(a, b).autoAttach(true);
+			let list = new ManagedList(a, b).attachAll(true);
 			list.replace([b, a]);
 			expect(a.isUnlinked()).toBeFalsy();
 			expect(b.isUnlinked()).toBeFalsy();
@@ -627,7 +627,7 @@ describe("ManagedList", () => {
 
 		test("Remove attached object when unlinked", () => {
 			let a = new NamedObject("a");
-			let list = new ManagedList(a).autoAttach(true);
+			let list = new ManagedList(a).attachAll(true);
 			expect(ManagedObject.whence(a)).toBe(list);
 			a.unlink();
 			expect(ManagedObject.whence(a)).toBeUndefined();
@@ -708,7 +708,7 @@ describe("ManagedList", () => {
 
 		test("Object removed event: unlink attached object", () => {
 			let a = new NamedObject("a");
-			let list = new ManagedList(a).autoAttach(true);
+			let list = new ManagedList(a).attachAll(true);
 			let observer = new ListEventObserver().observe(list);
 			a.unlink();
 			expect(observer.removed).toBe(1);
@@ -722,10 +722,10 @@ describe("ManagedList", () => {
 
 		test("Object removed event: move attached object", (t) => {
 			let a = new NamedObject("a");
-			let list = new ManagedList(a).autoAttach(true);
+			let list = new ManagedList(a).attachAll(true);
 			expect(ManagedObject.whence(a)).toBe(list);
 			t.log(list.toArray());
-			let other = new ManagedList().autoAttach(true);
+			let other = new ManagedList().attachAll(true);
 			let observer = new ListEventObserver().observe(list);
 			other.add(a);
 			expect(ManagedObject.whence(a)).toBe(other);
@@ -770,7 +770,7 @@ describe("ManagedList", () => {
 
 		test("List change event: clear (attached)", () => {
 			let a = new NamedObject("a");
-			let list = new ManagedList(a).autoAttach(true);
+			let list = new ManagedList(a).attachAll(true);
 			let observer = new ListEventObserver().observe(list);
 			list.clear();
 			expect(observer.removed).toBe(0);

--- a/packages/frame-core/test/tests/base/managedobject.ts
+++ b/packages/frame-core/test/tests/base/managedobject.ts
@@ -45,7 +45,7 @@ describe("ManagedObject", () => {
 		class TestObject extends ManagedObject {
 			constructor() {
 				super();
-				this.observeAttach("child");
+				this.autoAttach("child");
 			}
 			id = id++;
 			child?: ChildObject = new ChildObject();
@@ -114,7 +114,7 @@ describe("ManagedObject", () => {
 			class MyLoop extends ManagedObject {
 				constructor() {
 					super();
-					this.observeAttach("loop");
+					this.autoAttach("loop");
 				}
 				loop?: MyLoop;
 				attachLoop() {

--- a/packages/frame-core/test/tests/base/managedrecord.ts
+++ b/packages/frame-core/test/tests/base/managedrecord.ts
@@ -22,7 +22,7 @@ describe("ManagedRecord", () => {
 	});
 
 	test("Find sibling records", () => {
-		let list = new ManagedList().autoAttach(true);
+		let list = new ManagedList().attachAll(true);
 		let a = ManagedRecord.create({ name: "a" });
 		let b = ManagedRecord.create({ name: "b" });
 		list.add(a, b);
@@ -39,7 +39,7 @@ describe("ManagedRecord", () => {
 		list.add(a, b);
 		expect(a.getNextSibling()).toBeUndefined();
 		expect(b.getPreviousSibling()).toBeUndefined();
-		list.autoAttach(true);
+		list.attachAll(true);
 		expect(a.getNextSibling()).toBe(b);
 	});
 

--- a/packages/frame-core/test/tests/base/observer.ts
+++ b/packages/frame-core/test/tests/base/observer.ts
@@ -10,7 +10,7 @@ describe("Observers", () => {
 	class MyObject extends ManagedObject {
 		constructor() {
 			super();
-			this.observeAttach("child");
+			this.autoAttach("child");
 			let dynamic = false;
 			Object.defineProperty(this, "dynamic", {
 				configurable: true,
@@ -845,7 +845,7 @@ describe("Observers", () => {
 				foo?: MyObject;
 				go() {
 					this.foo = new MyObject();
-					this.observeAttach("foo", new MyObserver(t));
+					this.autoAttach("foo", new MyObserver(t));
 					this.foo.emit("Foo");
 				}
 			}
@@ -859,7 +859,7 @@ describe("Observers", () => {
 				foo?: MyObject;
 				go() {
 					this.foo = new MyObject();
-					this.observeAttach("foo", (target, event) => {
+					this.autoAttach("foo", (target, event) => {
 						if (event) t.count("change");
 						if (target instanceof MyObject) t.count("observe");
 					});
@@ -875,7 +875,7 @@ describe("Observers", () => {
 			class MyObject extends ManagedObject {
 				foo?: MyObject;
 				go() {
-					this.observeAttach("foo", new MyObserver(t));
+					this.autoAttach("foo", new MyObserver(t));
 					this.foo = new MyObject();
 					this.foo.emit("Foo");
 					this.foo = new MyObject();
@@ -891,7 +891,7 @@ describe("Observers", () => {
 			class MyObject extends ManagedObject {
 				foo?: MyObject;
 				go() {
-					this.observeAttach("foo", (target, event) => {
+					this.autoAttach("foo", (target, event) => {
 						if (event) t.count("change");
 						if (target instanceof MyObject) t.count("observe");
 						else if (!target) t.count("stop");
@@ -912,7 +912,7 @@ describe("Observers", () => {
 			class MyObject extends ManagedObject {
 				foo?: MyObject;
 				go() {
-					this.observeAttach("foo", new MyObserver(t));
+					this.autoAttach("foo", new MyObserver(t));
 					this.foo = new MyObject();
 					this.foo.emit("Foo");
 					this.foo.unlink();
@@ -929,7 +929,7 @@ describe("Observers", () => {
 			class MyObject extends ManagedObject {
 				foo?: MyObject;
 				go() {
-					this.observeAttach("foo", (target, event) => {
+					this.autoAttach("foo", (target, event) => {
 						if (event) t.count("change");
 						if (target instanceof MyObject) t.count("observe");
 						else if (!target) t.count("stop");
@@ -950,7 +950,7 @@ describe("Observers", () => {
 			class MyObject extends ManagedObject {
 				foo?: MyObject;
 				go() {
-					this.observeAttach("foo", new MyObserver(t));
+					this.autoAttach("foo", new MyObserver(t));
 					this.foo = new MyObject();
 					this.foo.emit("Foo");
 					expect(
@@ -971,7 +971,7 @@ describe("Observers", () => {
 			class MyObject extends ManagedObject {
 				foo?: MyObject;
 				go() {
-					this.observeAttach("foo", (target, event) => {
+					this.autoAttach("foo", (target, event) => {
 						if (event) t.count("change");
 						if (target instanceof MyObject) t.count("observe");
 						else if (!target) t.count("stop");

--- a/packages/frame-core/test/tests/ui/list.ts
+++ b/packages/frame-core/test/tests/ui/list.ts
@@ -96,7 +96,7 @@ describe("UIList", (scope) => {
 		class ArrayProvider extends ManagedObject {
 			constructor() {
 				super();
-				this.observeAttach("view");
+				this.autoAttach("view");
 			}
 			declare view?: UIList;
 			array = ["a", "b", "c"];

--- a/packages/frame-core/test/tests/ui/viewrender.ts
+++ b/packages/frame-core/test/tests/ui/viewrender.ts
@@ -104,7 +104,7 @@ describe("UIViewRenderer", (scope) => {
 			);
 			constructor() {
 				super();
-				this.observeAttach("second");
+				this.autoAttach("second");
 				this.second = new MySecondActivity();
 			}
 			declare second?: MySecondActivity;

--- a/packages/www/content/en/docs/main/guide/Activities.md
+++ b/packages/www/content/en/docs/main/guide/Activities.md
@@ -83,7 +83,7 @@ In addition, you can use the {@link ManagedObject.beforeUnlink()} method to impl
 
 ## Nesting activities {#nesting}
 
-Activities can be nested by attaching one activity to another using the {@link ManagedObject.attach} or {@link ManagedObject.observeAttach} methods. No particular behavior is enforced for nested activities, and nested activities can be activated and deactivated independently. Nested activities simply provide a way to organize activities into a hierarchy instead of having to add them all at the root level.
+Activities can be nested by attaching one activity to another using the {@link ManagedObject.attach} or {@link ManagedObject.autoAttach} methods. No particular behavior is enforced for nested activities, and nested activities can be activated and deactivated independently. Nested activities simply provide a way to organize activities into a hierarchy instead of having to add them all at the root level.
 
 Only paths for automatic activation and deactivation (routing) are treated specially for nested activities, and they can also be used to implement navigation patterns — see below.
 

--- a/packages/www/content/en/docs/main/guide/Data structures.md
+++ b/packages/www/content/en/docs/main/guide/Data structures.md
@@ -141,9 +141,9 @@ This is best explained with an example that relates to UI containers:
 - Therefore, any bindings on view objects are able to bind to properties of the {@link UIContainer} object and _its_ attached parent objects.
 - When the {@link UIContainer} is unlinked, so is the content list, and therefore all of the objects within the list.
 
-Refer to the documentation of {@link ManagedList.autoAttach()} for details.
+Refer to the documentation of {@link ManagedList.attachAll()} for details.
 
-- {@ref ManagedList.autoAttach}
+- {@ref ManagedList.attachAll}
 
 This pattern is not just reserved for UI components and views, but can also be used for data models. In the case of managed records, attaching a record to a list allows its {@link ManagedRecord.getParentRecord getParentRecord()}, {@link ManagedRecord.getNextSibling getNextSibling()}, and {@link ManagedRecord.getPreviousSibling getPreviousSibling()} to find related records.
 
@@ -151,7 +151,7 @@ This pattern is not just reserved for UI components and views, but can also be u
 class Customer extends ManagedRecord {
 	// ...
 	readonly contacts = this.attach(
-		new ManagedList().restrict(Contact).autoAttach(true),
+		new ManagedList().restrict(Contact).attachAll(true),
 	);
 }
 
@@ -168,7 +168,7 @@ contact1.getNextSibling(); // contact2
 
 Attaching objects to managed lists not only conveys ownership, but also allows lists to handle and **propagate** events from each object it contains.
 
-By default, event propagation is enabled along with auto-attachment using the {@link ManagedList.autoAttach autoAttach()} method. To _disable_ event propagation, set the second parameter of this method to false.
+By default, event propagation is enabled along with auto-attachment using the {@link ManagedList.attachAll attachAll()} method. To _disable_ event propagation, set the second parameter of this method to false.
 
 After enabling auto-attachment and event propagating, _all events_ emitted on objects in the list are re-emitted by the list itself — propagating the event from the object to the list, allowing it to be handled by the object that contains it.
 
@@ -180,7 +180,7 @@ This mechanism can be combined with handling change events that are emitted by t
 class Customer extends ManagedRecord {
 	// ...
 	readonly contacts = this.attach(
-		new ManagedList().restrict(Contact).autoAttach(true),
+		new ManagedList().restrict(Contact).attachAll(true),
 		(list, changeEvent) => {
 			// ... handle a change to OR within the list
 			// (use changeEvent.source to find the object)

--- a/packages/www/content/en/docs/main/guide/Events observers.md
+++ b/packages/www/content/en/docs/main/guide/Events observers.md
@@ -7,7 +7,7 @@ sort: -10
 applies_to:
   - ManagedObject
   - ManagedObject.attach
-  - ManagedObject.observeAttach
+  - ManagedObject.autoAttach
   - ManagedObject.emit
   - ManagedObject.emitChange
   - ManagedEvent
@@ -59,7 +59,7 @@ To emit a change event, instantiate a {@link ManagedChangeEvent} object first, o
 
 ## Handling change events from attached objects {#attached-events}
 
-When attaching an object using {@link ManagedObject.attach()}, or adding an observed property using {@link ManagedObject.observeAttach()}, you can provide a callback function that's invoked when —
+When attaching an object using {@link ManagedObject.attach()}, or adding an observed property using {@link ManagedObject.autoAttach()}, you can provide a callback function that's invoked when —
 
 - an object is attached,
 - an attached object is unlinked or otherwise detached, or
@@ -68,7 +68,7 @@ When attaching an object using {@link ManagedObject.attach()}, or adding an obse
 Refer to the documentation for these methods to learn more.
 
 - {@ref ManagedObject.attach}
-- {@ref ManagedObject.observeAttach}
+- {@ref ManagedObject.autoAttach}
 
 Alternatively, you can provide an {@link Observer} object instead of a callback function. An observer class would be able to handle _any_ event as well as property changes (refer to the sections about observers below).
 

--- a/packages/www/content/en/docs/main/guide/Fundamentals.md
+++ b/packages/www/content/en/docs/main/guide/Fundamentals.md
@@ -7,7 +7,7 @@ sort: -20
 applies_to:
   - ManagedObject
   - ManagedObject.attach
-  - ManagedObject.observeAttach
+  - ManagedObject.autoAttach
   - ManagedObject.emit
   - ManagedObject.emitChange
   - ManagedEvent
@@ -67,7 +67,7 @@ This pattern has two main advantages for managing an application at runtime:
 Use the following methods to attach and detach objects.
 
 - {@ref ManagedObject.attach}
-- {@ref ManagedObject.observeAttach}
+- {@ref ManagedObject.autoAttach}
 - {@ref ManagedObject.unlink}
 
 #### Example
@@ -83,13 +83,13 @@ class MyObject extends ManagedObject {
 }
 ```
 
-On the other hand, watched properties are usually not initialized right away, and the call to `observeAttach` is best placed in a constructor.
+On the other hand, watched properties are usually not initialized right away, and the call to `autoAttach` is best placed in a constructor.
 
 ```ts
 class MyObject extends ManagedObject {
 	constructor() {
 		super();
-		this.observeAttach("someObject");
+		this.autoAttach("someObject");
 	}
 
 	// This property is watched
@@ -128,7 +128,7 @@ Rather than attaching objects one by one, you can also attach objects using _man
 - After a list is attached to a {@link ManagedObject} (which includes any other list), all objects contained by it are attached to the list itself.
 - Any objects that are added to the list afterwards, are also automatically attached to it.
 - When an object is unlinked, it's removed from the list automatically.
-- To prevent this behavior, you can use the {@link ManagedList.autoAttach autoAttach()} method.
+- To prevent this behavior, you can use the {@link ManagedList.attachAll attachAll()} method.
 
 Refer to the documentation below to learn more about managed lists.
 


### PR DESCRIPTION
- Rename attach methods (observeAttach => autoAttach)
- Add a method to stop bindings from passing beyond activities and services — instead, trying to bind to a non-existent property will result in an unhandled error.