### PR TITLE
Limit bindings to app only

### DIFF
--- a/packages/frame-core/src/app/Activity.ts
+++ b/packages/frame-core/src/app/Activity.ts
@@ -1,5 +1,4 @@
 import {
-	Binding,
 	bound,
 	ConfigOptions,
 	ManagedObject,
@@ -66,7 +65,6 @@ export class Activity extends ManagedObject {
 	 */
 	constructor() {
 		super();
-		Binding.limitTo(this);
 		_boundActivationPath.bindTo(this, "activationPath");
 
 		// create observer to match path and activate/deactivate

--- a/packages/frame-core/src/app/GlobalContext.ts
+++ b/packages/frame-core/src/app/GlobalContext.ts
@@ -1,23 +1,24 @@
 import {
+	Binding,
 	ConfigOptions,
 	LazyString,
 	ManagedObject,
 	StringConvertible,
 } from "../base/index.js";
-import { err, ERROR, errorHandler, setErrorHandler } from "../errors.js";
+import { ERROR, err, errorHandler, setErrorHandler } from "../errors.js";
+import { UITheme } from "../ui/UITheme.js";
 import { ActivationContext } from "./ActivationContext.js";
-import { ServiceContext } from "./ServiceContext.js";
+import type { ActivationPath } from "./ActivationPath.js";
 import type { Activity } from "./Activity.js";
 import type { I18nProvider } from "./I18nProvider.js";
-import type { NavigationTarget } from "./NavigationTarget.js";
-import type { ActivationPath } from "./ActivationPath.js";
-import type { RenderContext } from "./RenderContext.js";
-import type { ViewportContext } from "./ViewportContext.js";
-import { UITheme } from "../ui/UITheme.js";
-import { Scheduler } from "./Scheduler.js";
 import { LogWriter } from "./LogWriter.js";
 import { MessageDialogOptions } from "./MessageDialogOptions.js";
+import type { NavigationTarget } from "./NavigationTarget.js";
+import type { RenderContext } from "./RenderContext.js";
+import { Scheduler } from "./Scheduler.js";
 import { Service } from "./Service.js";
+import { ServiceContext } from "./ServiceContext.js";
+import type { ViewportContext } from "./ViewportContext.js";
 
 /**
  * A singleton class that represents the global application state
@@ -35,6 +36,7 @@ export class GlobalContext extends ManagedObject {
 	private constructor() {
 		if (GlobalContext.instance) throw Error;
 		super();
+		Binding.limitTo(this);
 		this.autoAttach("services");
 		this.autoAttach("activities");
 		this.autoAttach("renderer");

--- a/packages/frame-core/src/app/Service.ts
+++ b/packages/frame-core/src/app/Service.ts
@@ -1,4 +1,4 @@
-import { Binding, ManagedObject } from "../base/index.js";
+import { ManagedObject } from "../base/index.js";
 import { ServiceContext } from "./ServiceContext.js";
 
 /**
@@ -12,11 +12,6 @@ import { ServiceContext } from "./ServiceContext.js";
  * @see {@link ServiceContext}
  */
 export abstract class Service extends ManagedObject {
-	constructor() {
-		super();
-		Binding.limitTo(this);
-	}
-
 	/** Returns true if this service is currently registered */
 	isServiceRegistered() {
 		// use duck typing to find out if parent map is a ServiceContext

--- a/packages/frame-core/src/base/Binding.ts
+++ b/packages/frame-core/src/base/Binding.ts
@@ -86,7 +86,7 @@ export class Binding<T = any> {
 
 	/**
 	 * Restricts bindings that can be bound to (attached parent objects of) the specified object, if the object itself does not include a corresponding property
-	 * @note This method is used automatically on {@link Activity} and {@link Service} objects, since any attempt to bind to a property that's not defined on the object itself is usually considered an error. To change the default behavior, call this method with a custom filter function.
+	 * @note This method is used automatically on the {@link app} object, since any attempt to bind to a property (e.g. from the view) should at least stop there. For further limitations, call this method with a filter to restrict bindings on any other object.
 	 * @param object The object for which to restrict bindings
 	 * @param filter A function that returns true if a property is allowed to pass, or false if an attempt to bind should result in an unhandled error; if not provided, no properties are allowed
 	 */


### PR DESCRIPTION
This moves the binding limitations from all activities and services, to the global context only. This allows for bindings to parent activities, as well as e.g. viewport context.