### PR TITLE
Add ManagedList.objects method

### DIFF
--- a/packages/frame-core/src/app/ServiceContext.ts
+++ b/packages/frame-core/src/app/ServiceContext.ts
@@ -8,7 +8,7 @@ import { Service } from "./Service.js";
  * A container of named services, part of the global application context
  *
  * @description
- * This class is a container for named services, which should be accessible by the rest of the application. Services can be set, unset, and replaced using the service context, and a {@link ServiceObserver} can be used to access the currently registered service with a particular name.
+ * This class is a container for named services, which should be accessible by the rest of the application. Services can be set, unset, and replaced using the service context, and a {@link ServiceObserver} can be used to access the currently registered service with a particular ID.
  *
  * - Use the {@link add()} method to add or update a service by ID. The service must be an instance of {@link Service} with a valid `id` property. The service is automatically attached to the ServiceContext instance.
  * - Unlink a service to remove it again.
@@ -53,8 +53,8 @@ export class ServiceContext extends ManagedObject {
 	}
 
 	/**
-	 * Attaches an observer to a particular named service
-	 * @param name The name of the service to be observed
+	 * Attaches an observer to a particular service by ID
+	 * @param id The ID of the service to be observed
 	 * @param observer An instance of {@link ServiceObserver}, if any; otherwise a plain {@link ServiceObserver} instance will be created, which exposes the current service as {@link ServiceObserver.service service}
 	 *
 	 * @example
@@ -67,7 +67,7 @@ export class ServiceContext extends ManagedObject {
 	 * }
 	 */
 	observeService<TService extends Service>(
-		name: string,
+		id: string,
 		observer:
 			| ServiceObserver<TService>
 			| ManagedObject.AttachObserverFunction<TService> = new ServiceObserver(),
@@ -78,7 +78,7 @@ export class ServiceContext extends ManagedObject {
 				TService
 			>(observer, ServiceObserver);
 		}
-		return observer.observeService(this, name);
+		return observer.observeService(this, id);
 	}
 
 	// keep track of services in a list, and forward events
@@ -136,20 +136,20 @@ class ServiceContextObserver<
 	TService extends Service,
 > extends Observer<ServiceContext> {
 	constructor(
-		public name: string,
+		public id: string,
 		public observer: ServiceObserver<TService>,
 	) {
 		super();
 	}
 	override observe(observed: ServiceContext) {
 		super.observe(observed);
-		let service = observed.get(this.name);
+		let service = observed.get(this.id);
 		if (service) this.observer.observe(service as TService);
 		return this;
 	}
 	protected override handleEvent(event: ManagedList.ChangeEvent<Service>) {
 		// TODO: use event to not always have to check this way?
-		let newService = this.observed!.get(this.name);
+		let newService = this.observed!.get(this.id);
 		if (newService && newService !== this.observer.observed) {
 			this.observer.observe(newService as TService);
 		}

--- a/packages/frame-core/src/base/ManagedList.ts
+++ b/packages/frame-core/src/base/ManagedList.ts
@@ -117,14 +117,21 @@ export class ManagedList<
 		return idx >= 0 && idx < this[$_list].map.size ? this.get(idx) : undefined;
 	}
 
+	/** Iterator symbol, alias of {@link objects()} method */
+	declare [Symbol.iterator]: () => IterableIterator<T>;
+
 	/**
-	 * Iterator symbol, enables managed lists to work with 'for...of' statements
+	 * Returns an iterable iterator for this list
+	 * - The iterable iterator can be used to iterate over the list using a 'for...of' statement, without being able to modify the list itself (similar to the `Array.values` method).
 	 * - If the list is unlinked, the iterator stops immediately.
 	 * @note The behavior of the iterator is undefined if the object _after_ the current object is removed, moved, or if another object is inserted before it. Removing the _current_ object or any previous objects during iteration is safe.
 	 */
-	[Symbol.iterator](): Iterator<T> {
+	objects(): IterableIterator<T> {
 		let head = this[$_list].h;
 		return {
+			[Symbol.iterator]() {
+				return this;
+			},
 			next: (): IteratorResult<T> => {
 				let o = head && head.o;
 				if (!this.isUnlinked() && o) {
@@ -531,6 +538,7 @@ export class ManagedList<
 	/**
 	 * Returns an array that contains all objects in the list
 	 * - If the list is unlinked, this method returns an empty array.
+	 * - If you only need to iterate over all values, use the {@link objects()} method instead.
 	 */
 	toArray() {
 		if (this.isUnlinked()) return [];
@@ -623,6 +631,9 @@ export class ManagedList<
 	/** @internal Linked list, containing all objects */
 	private readonly [$_list]: LinkedList<T>;
 }
+
+// set iterator to objects() method
+ManagedList.prototype[Symbol.iterator] = ManagedList.prototype.objects;
 
 export namespace ManagedList {
 	/** Type definition for an event that's emitted when elements are added to, removed from, or moved within a list */

--- a/packages/frame-core/test/tests/base/managedlist.ts
+++ b/packages/frame-core/test/tests/base/managedlist.ts
@@ -355,6 +355,26 @@ describe("ManagedList", () => {
 			];
 		}
 
+		test("Iterable iterator (objects)", (t) => {
+			let [list1, list2, orig] = makeLists();
+
+			t.log("list1...");
+			let i = 0;
+			for (let t of list1) expect(t).toBe(orig[i++]);
+			expect(i).toBe(orig.length);
+
+			t.log("list2...");
+			i = 0;
+			for (let t of list2) expect(t).toBe(orig[i++]);
+			expect(i).toBe(orig.length);
+
+			t.log("list2.objects...");
+			let iter = list2.objects();
+			i = 0;
+			for (let t of iter) expect(t).toBe(orig[i++]);
+			expect(i).toBe(orig.length);
+		});
+
 		test("get", () => {
 			let [list1, list2] = makeLists();
 			expect(list1.get(0)).toHaveProperty("name").toBe("a");


### PR DESCRIPTION
This adds a `ManagedList.objects()` method which returns an iterable iterator (i.e. same as Array.values), a read-only iterator that refers to itself for e.g. `for...of` loops.