### PR TITLE
Add `app.showPage` method

### DIFF
--- a/packages/frame-core/src/app/Activity.ts
+++ b/packages/frame-core/src/app/Activity.ts
@@ -40,7 +40,7 @@ const _boundTheme = bound("theme");
  *   path = "foo";
  *   protected ready() {
  *     this.view = new body(); // imported from a view file
- *     app.render(this.view);
+ *     app.showPage(this.view);
  *   }
  * }
  *

--- a/packages/frame-core/src/app/GlobalContext.ts
+++ b/packages/frame-core/src/app/GlobalContext.ts
@@ -230,20 +230,30 @@ export class GlobalContext extends ManagedObject {
 	/**
 	 * Renders the provided view using specified placement options
 	 *
-	 * @summary This method can be used to render any view object to the screen (or in-memory test output, when called from a test function), such as a {@link UICell} or {@link ViewComposite} instance. By default, the view is rendered as a full-screen page, but you can specify a different placement using the `place` argument.
+	 * @summary This method can be used to render any view object to the screen (or in-memory test output, when called from a test function), such as a {@link UICell} or {@link ViewComposite} instance.
 	 *
 	 * @param view The view object to be rendered
-	 * @param place Global view placement options, refer to {@link RenderContext.PlacementOptions}
+	 * @param place Mount element ID, or global view placement options, refer to {@link RenderContext.PlacementOptions}
 	 * @returns A new {@link RenderContext.DynamicRendererWrapper} instance, which can be used to control the rendered view
 	 * @error This method throws an error if the renderer hasn't been initialized yet.
 	 */
-	render(view: View, place?: RenderContext.PlacementOptions) {
+	render(view: View, place: string | RenderContext.PlacementOptions) {
 		if (!this.renderer) throw err(ERROR.GlobalContext_NoRenderer);
 		return new RenderContext.DynamicRendererWrapper().render(
 			view,
 			this.renderer.getRenderCallback(),
-			place || { mode: "page" },
+			typeof place === "string" ? { mode: "mount", mountId: place } : place,
 		);
+	}
+
+	/**
+	 * Displays a full-screen page with the specified content view
+	 * - The page will be displayed until the view is unlinked. Further rendered content will be placed on top, if any.
+	 * @param view The view object to be displayed
+	 * @error This method throws an error if the renderer hasn't been initialized yet.
+	 */
+	showPage(view: View) {
+		this.render(view, { mode: "page" });
 	}
 
 	/**

--- a/packages/frame-core/src/app/RenderContext.ts
+++ b/packages/frame-core/src/app/RenderContext.ts
@@ -39,19 +39,12 @@ export namespace RenderContext {
 	 * @description
 	 * This type describes how root view output elements are placed among other output. The following options are available:
 	 * - `none` — No output should be placed at all.
-	 * - `default` — Platform default (useful for testing, set by `app.render()`)
+	 * - `page` — The output should fill the entire screen, on top of other content.
+	 * - `dialog` — The output should appear on top of all other output, surrounded by a shaded margin.
+	 * - `modal` — The output should appear on top of all other output, surrounded by a shaded margin. A `CloseModal` event is emitted when touching or clicking outside of the modal view area, or pressing the Escape key.
 	 * - `mount` — The output should be 'mounted' within an existing output element, with a specified string ID (e.g. HTML element).
-	 * - `page` — The output should fill the entire screen, and replace other page content.
-	 * - `dialog` — The output should appear on top of all other output.
-	 * - `modal` — The output should appear on top of all other output, with an optional backdrop shader. A `CloseModal` event is emitted when touching or clicking outside of the modal view area, or pressing the Escape key.
 	 */
-	export type PlacementMode =
-		| "none"
-		| "default"
-		| "mount"
-		| "page"
-		| "dialog"
-		| "modal";
+	export type PlacementMode = "none" | "page" | "dialog" | "modal" | "mount";
 
 	/**
 	 * Type definition for global rendering placement options
@@ -199,7 +192,7 @@ export namespace RenderContext {
 
 	/**
 	 * A class that's used to render a view referenced by a property
-	 * - Objects of this type are created by the {@link RenderContext.render()} and {@link GlobalContext.render app.render()} methods, and are mostly used internally to keep track of rendering state asynchronously.
+	 * - Objects of this type are created by the {@link GlobalContext.render app.render()} method, and are mostly used internally to keep track of rendering state asynchronously.
 	 *
 	 * @hideconstructor
 	 */

--- a/packages/frame-core/src/app/View.ts
+++ b/packages/frame-core/src/app/View.ts
@@ -25,7 +25,7 @@ export type ViewEvent<
  * @description
  * The view is one of the main architectural components of a Desk application. It provides a method to render its encapsulated content, either directly or using a collection of built-in UI components.
  *
- * Views can be rendered on their own (using {@link GlobalContext.render app.render()}) or included as content within another view. In most cases, a top-level view is rendered from the {@link Activity.ready()} method.
+ * Views can be rendered on their own (using {@link GlobalContext.render app.render()}, {@link GlobalContext.showPage app.showPage()}, or {@link GlobalContext.showDialog app.showDialog()}) or included as content within another view. In most cases, a top-level view is rendered from the {@link Activity.ready()} method.
  *
  * The View class can't be used on its own. Instead, define views using the following classes and methods:
  * - {@link UIComponent} subclasses and their static `.with()` methods, e.g. `UIButton.with()`, which create **preset** view constructors for built-in UI components.

--- a/packages/frame-core/src/base/Binding.ts
+++ b/packages/frame-core/src/base/Binding.ts
@@ -74,7 +74,7 @@ export function isBinding<T = any>(value: any): value is Binding<T> {
  * export class MyActivity extends Activity {
  *   protected ready() {
  *     this.view = new BodyView();
- *     app.render(this.view);
+ *     app.showPage(this.view);
  *   }
  *   user = { name: "Foo Bar" };
  *   roles = ["Administrator", "Contributor", "Viewer"];

--- a/packages/frame-core/test/tests/app/testcontext.ts
+++ b/packages/frame-core/test/tests/app/testcontext.ts
@@ -147,7 +147,7 @@ describe("TestContext", () => {
 			let app = useTestContext((options) => {
 				options.renderFrequency = 5;
 			});
-			app.render(view);
+			app.showPage(view);
 			await app.renderer.expectOutputAsync(100, { source: view });
 		});
 
@@ -159,7 +159,7 @@ describe("TestContext", () => {
 			let app = useTestContext((options) => {
 				options.renderFrequency = 5;
 			});
-			app.render(view);
+			app.showPage(view);
 			await app.renderer.expectOutputAsync(100, { source: view.body! });
 		});
 
@@ -175,7 +175,7 @@ describe("TestContext", () => {
 			let app = useTestContext((options) => {
 				options.renderFrequency = 5;
 			});
-			app.render(view);
+			app.showPage(view);
 			let out = await app.renderer.expectOutputAsync(500, {
 				source: view.body!,
 			});
@@ -196,7 +196,7 @@ describe("TestContext", () => {
 			let app = useTestContext((options) => {
 				options.renderFrequency = 5;
 			});
-			let rendered = app.render(view);
+			let rendered = app.render(view, { mode: "page" });
 			await app.renderer.expectOutputAsync(100, { source: view.body! });
 			await rendered.removeAsync();
 			app.renderer.expectOutput({ type: "cell" }).toBeEmpty();
@@ -206,7 +206,7 @@ describe("TestContext", () => {
 			class MyActivity extends Activity {
 				protected override ready() {
 					this.view = new UICell();
-					app.render(this.view);
+					app.showPage(this.view);
 				}
 			}
 			let activity = new MyActivity();
@@ -221,7 +221,7 @@ describe("TestContext", () => {
 			class MyActivity extends Activity {
 				protected override ready() {
 					this.view = new UICell();
-					app.render(this.view);
+					app.showPage(this.view);
 				}
 			}
 			let activity = new MyActivity();
@@ -351,7 +351,7 @@ describe("TestContext", () => {
 				options.renderFrequency = 5;
 			});
 			let button = new UIPrimaryButton("Test");
-			app.render(button);
+			app.showPage(button);
 			await t.expectOutputAsync(100, { type: "button" });
 			let p = app.showModalMenuAsync(
 				new UITheme.MenuOptions([

--- a/packages/frame-core/test/tests/ui/button.ts
+++ b/packages/frame-core/test/tests/ui/button.ts
@@ -87,7 +87,7 @@ describe("UIButton", (scope) => {
 			label: "foo",
 			accessibleLabel: "My button",
 		});
-		app.render(new MyButton());
+		app.showPage(new MyButton());
 		await t.expectOutputAsync(100, {
 			text: "foo",
 			accessibleLabel: "My button",
@@ -102,7 +102,7 @@ describe("UIButton", (scope) => {
 				bold: true,
 			},
 		});
-		app.render(new MyButton());
+		app.showPage(new MyButton());
 		await t.expectOutputAsync(100, {
 			text: "foo",
 			styles: {
@@ -117,7 +117,7 @@ describe("UIButton", (scope) => {
 		class MyActivity extends Activity {
 			protected override ready() {
 				this.view = new ViewBody();
-				app.render(this.view);
+				app.showPage(this.view);
 			}
 			onButtonClicked() {
 				t.count("clicked");
@@ -137,7 +137,7 @@ describe("UIButton", (scope) => {
 		class MyActivity extends Activity {
 			protected override ready() {
 				this.view = new MyButton();
-				app.render(this.view);
+				app.showPage(this.view);
 			}
 		}
 		app.addActivity(new MyActivity(), true);

--- a/packages/frame-core/test/tests/ui/cell.ts
+++ b/packages/frame-core/test/tests/ui/cell.ts
@@ -63,7 +63,7 @@ describe("UICell", (scope) => {
 
 	test("Rendered as cell", async (t) => {
 		let cell = new UICell();
-		app.render(cell);
+		app.showPage(cell);
 		await t.expectOutputAsync(100, { type: "cell" });
 	});
 
@@ -73,7 +73,7 @@ describe("UICell", (scope) => {
 			UILabel.withText("foo"),
 			UILabel.withText("bar"),
 		);
-		app.render(new MyCell());
+		app.showPage(new MyCell());
 		let out = await t.expectOutputAsync(100, {
 			type: "cell",
 			styles: { gravity: "end" },
@@ -90,7 +90,7 @@ describe("UICell", (scope) => {
 			},
 			UILabel.withText("foo"),
 		);
-		app.render(new MyCell());
+		app.showPage(new MyCell());
 		await t.expectOutputAsync(100, {
 			type: "cell",
 			styles: {
@@ -104,7 +104,7 @@ describe("UICell", (scope) => {
 
 	test("Rendered, then update style", async (t) => {
 		let cell = new UICell();
-		app.render(cell);
+		app.showPage(cell);
 		await t.expectOutputAsync(100, { type: "cell" });
 		cell.borderRadius = 8;
 		cell.layout = { distribution: "start" };
@@ -118,7 +118,7 @@ describe("UICell", (scope) => {
 
 	test("Rendered, then update content", async (t) => {
 		let cell = new UICell(new UILabel("foo"), new UILabel("bar"));
-		app.render(cell);
+		app.showPage(cell);
 		await t.expectOutputAsync(100, { type: "cell" });
 		cell.content.add(new UILabel("baz"));
 		let out = await t.expectOutputAsync(100, { type: "cell" });
@@ -137,7 +137,7 @@ describe("UICell", (scope) => {
 		let cell2 = new UICell();
 
 		// render cell 1 with labels first
-		app.render(new UICell(cell1, cell2));
+		app.showPage(new UICell(cell1, cell2));
 		let out1 = await t.expectOutputAsync(
 			100,
 			{ source: cell1 },

--- a/packages/frame-core/test/tests/ui/conditional.ts
+++ b/packages/frame-core/test/tests/ui/conditional.ts
@@ -38,7 +38,7 @@ describe("UIConditional", () => {
 		cell.listen((e) => {
 			if (e.name === "ButtonClick") t.count("click");
 		});
-		app.render(cell);
+		app.showPage(cell);
 		let expectButton = await t.expectOutputAsync(500, { type: "button" });
 
 		t.log("Clicking button");
@@ -66,7 +66,7 @@ describe("UIConditional", () => {
 		let view = new MyView();
 
 		t.log("Rendering view");
-		app.render(view);
+		app.showPage(view);
 
 		// after rendering, there should be a cell but no label
 		t.log("Checking for cell but no label");

--- a/packages/frame-core/test/tests/ui/focus.ts
+++ b/packages/frame-core/test/tests/ui/focus.ts
@@ -22,7 +22,7 @@ describe("Focus management", (scope) => {
 	test("Single element, initial focus", async (t) => {
 		let MyCell = UICell.with({ requestFocus: true, allowFocus: true });
 		let cell = new MyCell();
-		app.render(cell);
+		app.showPage(cell);
 		let elt = (await t.expectOutputAsync(100, { type: "cell" })).getSingle();
 		expect(elt.hasFocus()).toBeTruthy();
 	});
@@ -30,7 +30,7 @@ describe("Focus management", (scope) => {
 	test("Single element, request focus", async (t) => {
 		let MyCell = UICell.with({ allowFocus: true });
 		let cell = new MyCell();
-		app.render(cell);
+		app.showPage(cell);
 		await t.expectOutputAsync(100, { type: "cell" });
 		cell.requestFocus();
 		await t.expectOutputAsync(100, { type: "cell", focused: true });
@@ -44,7 +44,7 @@ describe("Focus management", (scope) => {
 			}
 		}
 		let view = new MyView();
-		app.render(view);
+		app.showPage(view);
 		await t.expectOutputAsync(100, { type: "cell" });
 		view.requestFocus();
 		await t.expectOutputAsync(100, { type: "cell", focused: true });
@@ -57,7 +57,7 @@ describe("Focus management", (scope) => {
 		);
 
 		t.log("Focusing first");
-		app.render(new MyCell());
+		app.showPage(new MyCell());
 		let out = await t.expectOutputAsync(100, { text: "first", focused: true });
 
 		t.log("Focusing next");
@@ -105,7 +105,7 @@ describe("Focus management", (scope) => {
 				done = true;
 			}
 		}
-		app.render(new MyView());
+		app.showPage(new MyView());
 		await t.pollAsync(() => done, 5);
 		expect(events).toBeArray(["FocusIn", "FocusOut"]);
 	});

--- a/packages/frame-core/test/tests/ui/form.ts
+++ b/packages/frame-core/test/tests/ui/form.ts
@@ -205,7 +205,7 @@ describe("UIForm and UIFormContext", () => {
 		class MyActivity extends Activity {
 			protected override ready() {
 				this.view = new ViewBody();
-				app.render(this.view);
+				app.showPage(this.view);
 			}
 			form1 = new UIFormContext({ text: "foo" });
 			form2 = new UIFormContext({ text: "bar" });

--- a/packages/frame-core/test/tests/ui/image.ts
+++ b/packages/frame-core/test/tests/ui/image.ts
@@ -45,7 +45,7 @@ describe("UIImage", (scope) => {
 			accessibleLabel: "My image",
 		});
 		let image = new MyImage();
-		app.render(image);
+		app.showPage(image);
 		await t.expectOutputAsync(100, {
 			type: "image",
 			imageUrl: "foo.png",

--- a/packages/frame-core/test/tests/ui/jsx.tsx
+++ b/packages/frame-core/test/tests/ui/jsx.tsx
@@ -128,7 +128,7 @@ describe("JSX", () => {
 		useTestContext((options) => {
 			options.renderFrequency = 5;
 		});
-		app.render(new (MyView.with({ foo: 123 }))());
+		app.showPage(new (MyView.with({ foo: 123 }))());
 		await t.expectOutputAsync(50, { text: "123" });
 	});
 
@@ -140,7 +140,7 @@ describe("JSX", () => {
 		useTestContext((options) => {
 			options.renderFrequency = 5;
 		});
-		app.render(new (MyView.with({ foo: 123 }))());
+		app.showPage(new (MyView.with({ foo: 123 }))());
 		await t.expectOutputAsync(50, { text: "Foo is 123" });
 	});
 
@@ -157,7 +157,7 @@ describe("JSX", () => {
 			options.renderFrequency = 5;
 		});
 		let V = MyView.with({ foo: 123, bar: { foo: 456, baz: "abc" } });
-		app.render(new V());
+		app.showPage(new V());
 		let expectRow = await t.expectOutputAsync(50, { type: "row" });
 		t.log("straight binding");
 		expectRow.containing({ text: "foo='123'" }).toBeRendered();
@@ -181,7 +181,7 @@ describe("JSX", () => {
 		useTestContext((options) => {
 			options.renderFrequency = 5;
 		});
-		app.render(new Preset1());
+		app.showPage(new Preset1());
 		await t.sleep(20);
 		await t.expectOutputAsync(50, { text: "You have 1 email" });
 
@@ -198,7 +198,7 @@ describe("JSX", () => {
 			}
 		}
 		app.i18n = new MyI18nProvider();
-		app.render(new Preset2());
+		app.showPage(new Preset2());
 		await t.expectOutputAsync(50, { text: "Je hebt 2 e-mails" });
 	});
 });

--- a/packages/frame-core/test/tests/ui/label.ts
+++ b/packages/frame-core/test/tests/ui/label.ts
@@ -100,7 +100,7 @@ describe("UILabel", (scope) => {
 			accessibleLabel: "My label",
 		});
 		let label = new MyLabel();
-		app.render(label);
+		app.showPage(label);
 		await t.expectOutputAsync(100, {
 			text: "foo",
 			accessibleLabel: "My label",
@@ -113,7 +113,7 @@ describe("UILabel", (scope) => {
 			UILabelStyle.override({ bold: true }),
 		);
 		let MyLabel2 = UILabel.withText("two", { bold: true });
-		app.render(new UICell(new MyLabel1(), new MyLabel2()));
+		app.showPage(new UICell(new MyLabel1(), new MyLabel2()));
 		let match = await t.expectOutputAsync(100, {
 			type: "label",
 			styles: { bold: true },
@@ -128,7 +128,7 @@ describe("UILabel", (scope) => {
 			labelStyle: { bold: true },
 		});
 		let label = new MyLabel();
-		app.render(label);
+		app.showPage(label);
 		await t.expectOutputAsync(100, {
 			text: "foo",
 			styles: { width: 100, bold: true },
@@ -138,7 +138,7 @@ describe("UILabel", (scope) => {
 	test("Rendered, hidden and shown", async (t) => {
 		let label = new UILabel("foo");
 		let view = new UICell(label);
-		app.render(view);
+		app.showPage(view);
 		await t.expectOutputAsync(100, { type: "label", text: "foo" });
 		label.hidden = true;
 		let out = await t.expectOutputAsync(100, {

--- a/packages/frame-core/test/tests/ui/list.ts
+++ b/packages/frame-core/test/tests/ui/list.ts
@@ -62,7 +62,7 @@ describe("UIList", (scope) => {
 
 	test("Empty list, rendered", async (t) => {
 		let MyList = UIList.with({}, UILabel);
-		app.render(new MyList());
+		app.showPage(new MyList());
 		await t.expectOutputAsync(50, { type: "column" });
 	});
 
@@ -78,7 +78,7 @@ describe("UIList", (scope) => {
 		let instance = new MyList();
 
 		t.log("Rendering");
-		app.render(instance);
+		app.showPage(instance);
 		let out = await t.expectOutputAsync(50, { type: "row" });
 		expect(out.elements[0], "row element").toBeDefined();
 		out.containing({ text: "a" }).toBeRendered("list element a");
@@ -111,7 +111,7 @@ describe("UIList", (scope) => {
 		parent.view = instance;
 
 		t.log("Rendering");
-		app.render(instance);
+		app.showPage(instance);
 		await t.expectOutputAsync(50, { type: "row" });
 		expect(getListText(instance)).toBeArray(["a", "b", "c"]);
 	});
@@ -129,7 +129,7 @@ describe("UIList", (scope) => {
 		let instance = new MyList();
 
 		t.log("Rendering");
-		app.render(instance);
+		app.showPage(instance);
 		let out = await t.expectOutputAsync(50, { type: "row" }, { text: "c" });
 		let cRendered = out.getSingle();
 
@@ -163,7 +163,7 @@ describe("UIList", (scope) => {
 		});
 
 		t.log("Rendering");
-		app.render(view);
+		app.showPage(view);
 		let out = await t.expectOutputAsync(50, { text: "d" });
 
 		t.log("Clicking");
@@ -183,7 +183,7 @@ describe("UIList", (scope) => {
 		let instance = new MyList();
 
 		t.log("Rendering");
-		app.render(instance);
+		app.showPage(instance);
 		await t.expectOutputAsync(50, { type: "row" }, { text: "d" });
 		expect(getListText(instance)).toBeArray(["a", "b", "c", "d", "end"]);
 
@@ -203,7 +203,7 @@ describe("UIList", (scope) => {
 		let instance = new MyList();
 
 		t.log("Rendering 0-1");
-		app.render(instance);
+		app.showPage(instance);
 		await t.expectOutputAsync(50, { type: "row" });
 		expect(getListText(instance)).toBeArray(["a", "b"]);
 
@@ -235,7 +235,7 @@ describe("UIList", (scope) => {
 			UILabel.with({ text: bound("item.name"), allowFocus: true }),
 		);
 		let list = new Preset();
-		app.render(list);
+		app.showPage(list);
 		let out = await t.expectOutputAsync(50, { text: "a" });
 		expect(list.getIndexOfView(out.getSingle().output!.source)).toBe(0);
 		out = await t.expectOutputAsync(50, { text: "d" });
@@ -251,7 +251,7 @@ describe("UIList", (scope) => {
 				UILabel.with({ text: bound("item.name"), allowFocus: true }),
 			),
 		);
-		app.render(new Preset());
+		app.showPage(new Preset());
 		let out = await t.expectOutputAsync(50, { text: "a" });
 
 		t.log("Focus first item");
@@ -279,7 +279,7 @@ describe("UIList", (scope) => {
 			}),
 		);
 		let list = new Preset();
-		app.render(list);
+		app.showPage(list);
 		let firstOut = await t.expectOutputAsync(100, { text: "a" });
 
 		t.log("Focus first item");

--- a/packages/frame-core/test/tests/ui/rowcol.ts
+++ b/packages/frame-core/test/tests/ui/rowcol.ts
@@ -43,13 +43,13 @@ describe("UIRow and UIColumn", (scope) => {
 
 	test("Rendered as row", async (t) => {
 		let row = new UIRow();
-		app.render(row);
+		app.showPage(row);
 		await t.expectOutputAsync(100, { type: "row" });
 	});
 
 	test("Rendered as column", async (t) => {
 		let col = new UIColumn();
-		app.render(col);
+		app.showPage(col);
 		await t.expectOutputAsync(100, { type: "column" });
 	});
 
@@ -58,7 +58,7 @@ describe("UIRow and UIColumn", (scope) => {
 			{ height: 123 },
 			UIColumn.with({ width: 123 }, UILabel.withText("foo")),
 		);
-		app.render(new Preset());
+		app.showPage(new Preset());
 
 		// wait for row > col > label to be rendered
 		// and check row height

--- a/packages/frame-core/test/tests/ui/scrollcont.ts
+++ b/packages/frame-core/test/tests/ui/scrollcont.ts
@@ -55,7 +55,7 @@ describe("UIScrollContainer", (scope) => {
 	test("Rendered as container", async (t) => {
 		let cont = new UIScrollContainer();
 		cont.content.add(new UILabel("foo"));
-		app.render(cont);
+		app.showPage(cont);
 		await t.expectOutputAsync(50, { type: "container" }, { text: "foo" });
 	});
 });

--- a/packages/frame-core/test/tests/ui/separator.ts
+++ b/packages/frame-core/test/tests/ui/separator.ts
@@ -34,7 +34,7 @@ describe("UISeparator", (scope) => {
 	});
 
 	test("Rendered", async (t) => {
-		app.render(new UISeparator());
+		app.showPage(new UISeparator());
 		await t.expectOutputAsync(100, { type: "separator" });
 	});
 });

--- a/packages/frame-core/test/tests/ui/spacer.ts
+++ b/packages/frame-core/test/tests/ui/spacer.ts
@@ -31,7 +31,7 @@ describe("UISpacer", (scope) => {
 	});
 
 	test("Rendered", async (t) => {
-		app.render(new UISpacer());
+		app.showPage(new UISpacer());
 		await t.expectOutputAsync(50, { type: "spacer" });
 	});
 });

--- a/packages/frame-core/test/tests/ui/textfield.ts
+++ b/packages/frame-core/test/tests/ui/textfield.ts
@@ -38,7 +38,7 @@ describe("UITextField", (scope) => {
 	});
 
 	test("Rendered with placeholder", async (t) => {
-		app.render(new UITextField("foo", "bar"));
+		app.showPage(new UITextField("foo", "bar"));
 		await t.expectOutputAsync(100, {
 			text: "foo",
 			value: "bar",
@@ -47,7 +47,7 @@ describe("UITextField", (scope) => {
 
 	test("User input, directly setting value", async (t) => {
 		let tf = new UITextField();
-		app.render(tf);
+		app.showPage(tf);
 		let tfElt = (
 			await t.expectOutputAsync(100, { type: "textfield" })
 		).getSingle();
@@ -67,7 +67,7 @@ describe("UITextField", (scope) => {
 
 		// render field, check that value is 'bar'
 		t.log("Rendering with value");
-		app.render(tf);
+		app.showPage(tf);
 		let tfElt = (
 			await t.expectOutputAsync(100, { type: "textfield" })
 		).getSingle();

--- a/packages/frame-core/test/tests/ui/toggle.ts
+++ b/packages/frame-core/test/tests/ui/toggle.ts
@@ -37,7 +37,7 @@ describe("UIToggle", (scope) => {
 	});
 
 	test("Rendered with label", async (t) => {
-		app.render(new UIToggle("foo", true));
+		app.showPage(new UIToggle("foo", true));
 		await t.expectOutputAsync(100, {
 			text: "foo",
 			checked: true,
@@ -46,7 +46,7 @@ describe("UIToggle", (scope) => {
 
 	test("User input, directly setting checked value", async (t) => {
 		let toggle = new UIToggle();
-		app.render(toggle);
+		app.showPage(toggle);
 		let toggleElt = (
 			await t.expectOutputAsync(100, { type: "toggle" })
 		).getSingle();
@@ -66,7 +66,7 @@ describe("UIToggle", (scope) => {
 
 		// render field, check that checkbox is checked
 		t.log("Rendering with state");
-		app.render(toggle);
+		app.showPage(toggle);
 		let toggleElt = (
 			await t.expectOutputAsync(100, { type: "toggle" })
 		).getSingle();

--- a/packages/frame-core/test/tests/ui/viewrender.ts
+++ b/packages/frame-core/test/tests/ui/viewrender.ts
@@ -34,7 +34,7 @@ describe("UIViewRenderer", (scope) => {
 		let MyCell = UICell.with(UILabel.withText("foo"));
 		let viewRenderer = new UIViewRenderer();
 		viewRenderer.view = new MyCell();
-		app.render(viewRenderer);
+		app.showPage(viewRenderer);
 		await t.expectOutputAsync(50, { text: "foo" });
 		expect(viewRenderer.findViewContent(UILabel)).toBeArray(1);
 	});
@@ -44,7 +44,7 @@ describe("UIViewRenderer", (scope) => {
 		let MyCell2 = UICell.with(UILabel.withText("bar"));
 		let viewRenderer = new UIViewRenderer();
 		viewRenderer.view = new MyCell1();
-		app.render(viewRenderer);
+		app.showPage(viewRenderer);
 		await t.expectOutputAsync(50, { text: "foo" });
 		viewRenderer.view = new MyCell2();
 		await t.expectOutputAsync(50, { text: "bar" });
@@ -54,7 +54,7 @@ describe("UIViewRenderer", (scope) => {
 		let MyCell = UICell.with(UILabel.withText("foo"));
 		let viewRenderer = new UIViewRenderer();
 		viewRenderer.view = new MyCell();
-		app.render(viewRenderer);
+		app.showPage(viewRenderer);
 		await t.expectOutputAsync(50, { text: "foo" });
 		viewRenderer.view.unlink();
 		await t.sleep(20);
@@ -69,7 +69,7 @@ describe("UIViewRenderer", (scope) => {
 		class MyActivity extends Activity {
 			protected override ready() {
 				this.view = new (UIViewRenderer.with({ view: bound("vc") }))();
-				app.render(this.view);
+				app.showPage(this.view);
 			}
 			vc = this.attach(new Preset());
 		}
@@ -80,7 +80,7 @@ describe("UIViewRenderer", (scope) => {
 	test("Set view and focus", async (t) => {
 		let viewRenderer = new UIViewRenderer();
 		viewRenderer.view = new UITextField();
-		app.render(viewRenderer);
+		app.showPage(viewRenderer);
 		await t.expectOutputAsync(50, { type: "textfield", focused: false });
 		viewRenderer.requestFocus();
 		await t.expectOutputAsync(50, { type: "textfield", focused: true });
@@ -111,7 +111,7 @@ describe("UIViewRenderer", (scope) => {
 					UIViewRenderer.with({ view: bound("second.view") }),
 				);
 				this.view = new ViewBody();
-				app.render(this.view);
+				app.showPage(this.view);
 			}
 			declare second?: MySecondActivity;
 			onButtonPress(e: ManagedEvent) {

--- a/packages/frame-test/src/renderer/TestRenderer.ts
+++ b/packages/frame-test/src/renderer/TestRenderer.ts
@@ -51,7 +51,12 @@ export class TestRenderer extends RenderContext {
 					if (lastOutput && lastOutput !== output && lastOutput.element) {
 						(lastOutput.element as TestOutputElement).remove();
 					}
-					if (output && output.element) {
+					if (
+						output &&
+						output.element &&
+						output.place &&
+						output.place.mode !== "none"
+					) {
 						let elt = output.element as TestOutputElement;
 						if (!self._root.content.includes(elt)) {
 							self._root.content.push(elt);

--- a/packages/frame-test/test/tests/app.ts
+++ b/packages/frame-test/test/tests/app.ts
@@ -19,7 +19,7 @@ class CountActivity extends Activity {
 			UITextField.with({ value: bound("count"), onInput: "SetCount" }),
 			UIButton.withLabel("+", "CountUp"),
 		))();
-		app.render(this.view);
+		app.showPage(this.view);
 	}
 	override path = "count";
 	count = 0;
@@ -48,7 +48,7 @@ describe("App test", (scope) => {
 			UILabel.withText(p.title),
 		).with({ title: "TEST" });
 		let view = new MyView();
-		app.render(view);
+		app.showPage(view);
 		await t.expectOutputAsync(100, { text: "TEST" });
 	});
 

--- a/packages/frame-web/src/renderer/OutputMount.ts
+++ b/packages/frame-web/src/renderer/OutputMount.ts
@@ -13,13 +13,6 @@ let _nextId = 1;
 export class OutputMount {
 	readonly id = _nextId++;
 
-	/** Creates a plain (separate) root element, i.e. for placement mode "default" */
-	createElement() {
-		let elt = (this._outer = this._inner = document.createElement("desk-root"));
-		registerHandlers(elt);
-		document.body.appendChild(elt);
-	}
-
 	/** Creates a fixed full-page root element, i.e. for placement mode "page" */
 	createPageElement() {
 		let elt =

--- a/packages/frame-web/src/renderer/WebRenderer.ts
+++ b/packages/frame-web/src/renderer/WebRenderer.ts
@@ -76,9 +76,6 @@ export class WebRenderer extends RenderContext {
 						mount = new OutputMount();
 						this._mounts.set(mount.id, mount);
 						switch (output.place.mode) {
-							case "default":
-								mount.createElement();
-								break;
 							case "mount":
 								if (output.place.mountId) {
 									mount.findMountElement(output.place.mountId);

--- a/packages/frame-web/test/esbuild-es2015/src/main/MainActivity.tsx
+++ b/packages/frame-web/test/esbuild-es2015/src/main/MainActivity.tsx
@@ -18,7 +18,7 @@ export class MainActivity extends Activity {
 
 	protected override ready() {
 		this.view = new body();
-		app.render(this.view);
+		app.showPage(this.view);
 	}
 
 	selectedTheme: string = "light";

--- a/packages/frame-web/test/esbuild/src/counter.tsx
+++ b/packages/frame-web/test/esbuild/src/counter.tsx
@@ -14,7 +14,7 @@ const ViewBody = (
 export class CountActivity extends Activity {
 	ready() {
 		this.view = new ViewBody();
-		app.render(this.view);
+		app.showPage(this.view);
 	}
 
 	count = 0;

--- a/packages/frame-web/test/esm/src/counter.tsx
+++ b/packages/frame-web/test/esm/src/counter.tsx
@@ -18,7 +18,7 @@ const ViewBody = (
 export class CountActivity extends Activity {
 	ready() {
 		this.view = new ViewBody();
-		app.render(this.view);
+		app.showPage(this.view);
 	}
 
 	count = 0;

--- a/packages/frame-web/test/iife/test-iife.js
+++ b/packages/frame-web/test/iife/test-iife.js
@@ -17,7 +17,7 @@
 	class CountActivity extends desk.Activity {
 		ready() {
 			this.view = new ViewBody();
-			desk.app.render(this.view);
+			desk.app.showPage(this.view);
 		}
 		count = 0;
 		onCountDown() {

--- a/packages/frame-web/test/parcel/src/counter.tsx
+++ b/packages/frame-web/test/parcel/src/counter.tsx
@@ -14,7 +14,7 @@ const ViewBody = (
 export class CountActivity extends Activity {
 	protected ready() {
 		this.view = new ViewBody();
-		app.render(this.view);
+		app.showPage(this.view);
 	}
 
 	count = 0;

--- a/packages/frame-web/test/perf/src/perf.tsx
+++ b/packages/frame-web/test/perf/src/perf.tsx
@@ -32,7 +32,7 @@ const ViewBody = (
 export class PerfActivity extends Activity {
 	protected override ready() {
 		this.view = new ViewBody();
-		app.render(this.view);
+		app.showPage(this.view);
 	}
 	protected override async beforeActiveAsync() {
 		this.items = new Array(MAX);


### PR DESCRIPTION
This changes calls to `app.render` to `.showPage` to be in line with `.showDialog`.

`app.render` is now exclusively for using different placements. The second parameter can also be a string, i.e. a mount ID to make simple mounted app views easier to render.