### PR TITLE
Move service observer to Service and Activity

### DIFF
--- a/packages/frame-core/src/app/Service.ts
+++ b/packages/frame-core/src/app/Service.ts
@@ -1,13 +1,14 @@
-import { ManagedObject } from "../base/index.js";
+import { ManagedObject, Observer } from "../base/index.js";
+import { app } from "./GlobalContext.js";
 import { ServiceContext } from "./ServiceContext.js";
 
 /**
  * An abstract class that represents a named service
  *
  * @description
- * Services are instances of the `Service` class that are made available to the rest of your application _by ID_, using {@link ServiceContext}. Services can be _observed_, to watch for changes and listen for events.
+ * Services are instances of the `Service` class that are made available to the rest of your application _by ID_, using {@link ServiceContext} (available through {@link GlobalContext.services app.services}). Typically, services are observed from activities or other services, and provide shared functionality or data.
  *
- * To add a service, extend this class, create an instance, assign an ID, and add it to the service context using {@link GlobalContext.addService app.addService()}. When another service is added with the same ID, the existing service is replaced and unlinked.
+ * To add a service, extend the Service class, create an instance, assign an ID, and add it to the service context using {@link GlobalContext.addService app.addService()}. When another service is added with the same ID, the existing service is replaced and unlinked.
  *
  * @see {@link ServiceContext}
  */
@@ -26,4 +27,19 @@ export abstract class Service extends ManagedObject {
 
 	/** The unique ID for this service (instance) */
 	abstract id: string;
+
+	/**
+	 * Observes another service by ID, until the current service is unlinked
+	 * @param id The ID of the service to be observed
+	 * @param observer An {@link Observer} class or instance, or a function that's called whenever a change event is emitted by the target service (with service and event arguments, respectively), and when the target service is unlinked (without any arguments)
+	 * @returns The observer instance, which references the observed service using the {@link Observer.observed observed} property
+	 */
+	protected observeService<TService extends Service>(
+		id: string,
+		observer:
+			| Observer<TService>
+			| ManagedObject.AttachObserverFunction<TService> = new Observer(),
+	) {
+		return app.services._$observe(id, observer, this);
+	}
 }

--- a/packages/frame-core/src/app/ServiceContext.ts
+++ b/packages/frame-core/src/app/ServiceContext.ts
@@ -1,7 +1,6 @@
 import { ManagedList } from "../base/ManagedList.js";
 import { ManagedObject } from "../base/ManagedObject.js";
 import { Observer } from "../base/Observer.js";
-import { ManagedChangeEvent } from "../index.js";
 import { Service } from "./Service.js";
 
 /**
@@ -11,8 +10,9 @@ import { Service } from "./Service.js";
  * This class is a container for named services, which should be accessible by the rest of the application. Services can be set, unset, and replaced using the service context, and a {@link ServiceObserver} can be used to access the currently registered service with a particular ID.
  *
  * - Use the {@link add()} method to add or update a service by ID. The service must be an instance of {@link Service} with a valid `id` property. The service is automatically attached to the ServiceContext instance.
- * - Unlink a service to remove it again.
- * - Use the {@link ServiceContext.observeService observeService()} method to attach or create a {@link ServiceObserver} object.
+ * - Use the {@link get()} method to retrieve a service by ID, if one is currently registered.
+ * - Unlink a service to remove (unregister) it.
+ * - Use the {@link Activity.observeService()} or {@link Service.observeService()} methods to observe a particular service by ID and handle change events.
  *
  * @hideconstructor
  */
@@ -53,93 +53,48 @@ export class ServiceContext extends ManagedObject {
 	}
 
 	/**
-	 * Attaches an observer to a particular service by ID
+	 * @internal Attaches an observer to a particular service by ID, until the specified parent object is unlinked
 	 * @param id The ID of the service to be observed
-	 * @param observer An instance of {@link ServiceObserver}, if any; otherwise a plain {@link ServiceObserver} instance will be created, which exposes the current service as {@link ServiceObserver.service service}
-	 *
-	 * @example
-	 * // Use a service somewhere in your application:
-	 * const cart = app.services.observeService("MyApp.Cart");
-	 *
-	 * function addToCart(product) {
-	 *   if (!cart.service) throw CartNotFoundError();
-	 *   cart.service.add(product);
-	 * }
+	 * @param observer An observer instance or change event callback
+	 * @param parent The parent object to observe (for unlinking)
+	 * @returns The observer instance
 	 */
-	observeService<TService extends Service>(
+	_$observe<TService extends Service>(
 		id: string,
 		observer:
-			| ServiceObserver<TService>
-			| ManagedObject.AttachObserverFunction<TService> = new ServiceObserver(),
+			| Observer<TService>
+			| ManagedObject.AttachObserverFunction<TService> = new Observer(),
+		parent: ManagedObject,
 	) {
 		if (typeof observer === "function") {
-			observer = ServiceObserver.fromChangeHandler<
-				ServiceObserver<TService>,
-				TService
-			>(observer, ServiceObserver);
+			observer = Observer.fromChangeHandler<Observer<TService>, TService>(
+				observer,
+				Observer,
+			);
 		}
-		return observer.observeService(this, id);
+		new ServiceContextObserver(id, observer, parent).observe(this);
+		return observer;
 	}
 
 	// keep track of services in a list, and forward events
 	private _map?: Map<string, Service>;
-	private _list = this.attach(new ManagedList<Service>(), (_list, e) => {
-		if (e instanceof ManagedChangeEvent) {
-			this._map = new Map(this._list.map((s) => [s.id, s]));
-			this.emitChange();
-		}
+	private _list = this.attach(new ManagedList<Service>(), () => {
+		this._map = new Map(this._list.map((s) => [s.id, s]));
+		this.emitChange();
 	});
 }
 
-/**
- * An {@link Observer} class that automatically observes services as they're set or changed
- * - Instances are returned by the {@link ServiceContext.observeService()} method. This class may be extended to observe individual properties or handle events on a service if needed.
- * - Creating multiple observers for the same service may cause a memory leak. If you're creating new observers as part of your application (e.g. in a data model) be sure to use the {@link Observer.stop stop()} method when the observer is no longer needed.
- */
-export class ServiceObserver<
-	TService extends Service,
-> extends Observer<TService> {
-	/** The current service, updated automatically when services are added, updated, or removed */
-	get service() {
-		return this.observed;
-	}
-
-	/**
-	 * @internal Start observing a service
-	 * - This method is called automatically by {@link ServiceContext.observeService()}.
-	 */
-	observeService(context: ServiceContext, id: string) {
-		this._serviceContextObserver?.stop();
-		this._serviceContextObserver = new ServiceContextObserver(id, this).observe(
-			context,
-		);
-		return this;
-	}
-
-	/** Stops observing the service context _and_ current service */
-	override stop() {
-		// stop observing service and context
-		this._serviceContextObserver?.stop();
-		super.stop();
-	}
-
-	protected override handleUnlink() {
-		super.stop(); // stop observing, but not context
-	}
-
-	/** @internal Service context (map) observer instance */
-	private _serviceContextObserver?: ServiceContextObserver<TService>;
-}
-
-/** @internal Context observer used by a ServiceObserver */
+/** Context observer used by a ServiceObserver */
 class ServiceContextObserver<
 	TService extends Service,
 > extends Observer<ServiceContext> {
 	constructor(
 		public id: string,
-		public observer: ServiceObserver<TService>,
+		public observer: Observer<TService>,
+		parent: ManagedObject,
 	) {
 		super();
+		new ServiceContextObserver.ParentObserver(this).observe(parent);
 	}
 	override observe(observed: ServiceContext) {
 		super.observe(observed);
@@ -147,11 +102,25 @@ class ServiceContextObserver<
 		if (service) this.observer.observe(service as TService);
 		return this;
 	}
-	protected override handleEvent(event: ManagedList.ChangeEvent<Service>) {
-		// TODO: use event to not always have to check this way?
+	override stop() {
+		super.stop();
+		this.observer.stop();
+	}
+	protected override handleEvent() {
 		let newService = this.observed!.get(this.id);
 		if (newService && newService !== this.observer.observed) {
 			this.observer.observe(newService as TService);
 		}
 	}
+
+	/** Observer to stop a context observer when parent object (e.g. activity) is unlinked */
+	static ParentObserver = class extends Observer<ManagedObject> {
+		constructor(public contextObserver: ServiceContextObserver<Service>) {
+			super();
+		}
+		override stop() {
+			super.stop();
+			this.contextObserver.stop();
+		}
+	};
 }


### PR DESCRIPTION
This change reinforces the position of services in the app architecture. They're normally used from activities and other services, so it makes sense to observe them from there. The observer can then be automatically stopped when the activity or service is unlinked.