### PR TITLE
Remove sourcemap from dist folder

### DIFF
--- a/packages/frame-core/src/tsconfig.json
+++ b/packages/frame-core/src/tsconfig.json
@@ -13,7 +13,6 @@
 		"esModuleInterop": true,
 		"target": "esnext",
 		"lib": ["dom", "es2015"],
-		"outDir": "../dist",
-		"sourceMap": true
+		"outDir": "../dist"
 	}
 }

--- a/packages/frame-web/src/tsconfig.json
+++ b/packages/frame-web/src/tsconfig.json
@@ -13,7 +13,6 @@
 		"esModuleInterop": true,
 		"target": "esnext",
 		"lib": ["dom", "es2015"],
-		"outDir": "../dist",
-		"sourceMap": true
+		"outDir": "../dist"
 	}
 }


### PR DESCRIPTION
This removes the sourcemap from the distributed package — which was useless because the actual source was not included in the package anyway. Having the sourcemap in the published package confused bundlers and browsers.