### PR TITLE
Don't re-render views from showPage or showDialog

### DIFF
--- a/packages/frame-core/test/tests/app/testcontext.ts
+++ b/packages/frame-core/test/tests/app/testcontext.ts
@@ -202,6 +202,19 @@ describe("TestContext", () => {
 			app.renderer.expectOutput({ type: "cell" }).toBeEmpty();
 		});
 
+		test("View is not rendered twice", async () => {
+			const view = new UICell(new UILabel("Test"));
+			let app = useTestContext((options) => {
+				options.renderFrequency = 5;
+			});
+			app.showPage(view);
+			let out1 = await app.renderer.expectOutputAsync(100, { type: "label" });
+			view.findViewContent(UILabel)[0]!.text = "Foo";
+			app.showPage(view);
+			let out2 = await app.renderer.expectOutputAsync(100, { type: "label" });
+			expect(out2.elements).toBeArray(out1.elements);
+		});
+
 		test("Cell view from root activity", async () => {
 			class MyActivity extends Activity {
 				protected override ready() {


### PR DESCRIPTION
Showing the same view twice (e.g. from `activity.ready()` method) would create an additional wrapper and move the view output to the new wrapper. The app now doesn't re-render the same view when passed to these methods since it keeps track of rendered views in a `WeakMap`.