### PR TITLE
Make binding filters return new immutable binding objects

### DIFF
--- a/packages/frame-core/src/app/NavigationTarget.ts
+++ b/packages/frame-core/src/app/NavigationTarget.ts
@@ -37,7 +37,7 @@ export class NavigationTarget {
 
 	/**
 	 * Adds parameters to the navigation target path
-	 * @return The object itself
+	 * @returns The object itself
 	 */
 	append(...params: StringConvertible[]) {
 		this._detail = [this._detail, ...params]

--- a/packages/frame-core/test/tests/base/bindings.ts
+++ b/packages/frame-core/test/tests/base/bindings.ts
@@ -12,35 +12,35 @@ describe("Bindings", () => {
 	test("Constructor without params", () => {
 		expect(() => new Binding())
 			.not.toThrowError()
-			.toHaveProperty("isManagedBinding");
+			.toHaveProperty("isBinding");
 		expect(String(new Binding())).toBe("bound()");
 	});
 
 	test("Constructor with empty string", () => {
 		expect(() => new Binding(""))
 			.not.toThrowError()
-			.toHaveProperty("isManagedBinding");
+			.toHaveProperty("isBinding");
 	});
 
 	test("Global variants with empty string", () => {
 		expect(() => bound(""))
 			.not.toThrowError()
-			.toHaveProperty("isManagedBinding");
+			.toHaveProperty("isBinding");
 		expect(() => bound.number(""))
 			.not.toThrowError()
-			.toHaveProperty("isManagedBinding");
+			.toHaveProperty("isBinding");
 		expect(() => bound.string(""))
 			.not.toThrowError()
-			.toHaveProperty("isManagedBinding");
+			.toHaveProperty("isBinding");
 		expect(() => bound.boolean(""))
 			.not.toThrowError()
-			.toHaveProperty("isManagedBinding");
+			.toHaveProperty("isBinding");
 		expect(() => bound.not(""))
 			.not.toThrowError()
-			.toHaveProperty("isManagedBinding");
+			.toHaveProperty("isBinding");
 		expect(() => bound.list(""))
 			.not.toThrowError()
-			.toHaveProperty("isManagedBinding");
+			.toHaveProperty("isBinding");
 	});
 
 	test("Constructor with invalid argument", () => {
@@ -49,13 +49,13 @@ describe("Bindings", () => {
 
 	test("Constructor with path", () => {
 		let b = new Binding("x.y");
-		expect(b.isManagedBinding()).toBe(true);
+		expect(b.isBinding()).toBe(true);
 		expect(b).asString().toMatchRegExp(/x\.y/);
 	});
 
 	test("Constructor with path and filters", () => {
 		let b = new Binding("!x.y|!|!");
-		expect(b.isManagedBinding()).toBe(true);
+		expect(b.isBinding()).toBe(true);
 	});
 
 	describe("Basic bindings", () => {


### PR DESCRIPTION
This change makes `Binding` objects (mostly) immutable, so that filters such as `.not()` don't change the binding itself but return a new instance.

The use of chaining methods already suggested that this was the case (even though it wasn't), so this shouldn't be a breaking change in practice. Performance impact is apparently immeasurably small.