### PR TITLE
Add `expectMessageDialogAsync` method to TestCase

### DIFF
--- a/packages/frame-test/src/TestCase.ts
+++ b/packages/frame-test/src/TestCase.ts
@@ -391,6 +391,24 @@ export class TestCase {
 		return new OutputAssertion([]);
 	}
 
+	async expectMessageDialogAsync(
+		timeout: number,
+		...match: Array<string | RegExp>
+	) {
+		if (!(app.renderer instanceof TestRenderer)) {
+			throw Error("Test renderer not found, run `useTestContext()` first");
+		}
+		this._awaiting++;
+		try {
+			return await (app.renderer as TestRenderer).expectMessageDialogAsync(
+				timeout,
+				...match,
+			);
+		} finally {
+			this._awaiting--;
+		}
+	}
+
 	/** Runs this test case (used by {@link TestScope}) */
 	runTestAsync(timeout = DEFAULT_TIMEOUT) {
 		if (this._startT) throw Error("Test has already run");

--- a/packages/frame-test/test/tests/app.ts
+++ b/packages/frame-test/test/tests/app.ts
@@ -98,4 +98,30 @@ describe("App test", (scope) => {
 		btnElement.click();
 		expect(btnElement.hasFocus()).toBeTruthy();
 	});
+
+	test("Alert dialog can be dismissed", async (t) => {
+		let p = app.showAlertDialogAsync("Foo");
+		let dialog = await t.expectMessageDialogAsync(100, "Foo");
+		await dialog.confirmAsync();
+		let result = await p;
+		expect(result).toBeUndefined();
+	});
+
+	test("Confirm dialog can be cancelled", async (t) => {
+		let p = app.showConfirmDialogAsync("Foo?");
+		await (await t.expectMessageDialogAsync(100, /^Foo/)).cancelAsync();
+		let result = await p;
+		expect(result).toBeFalsy();
+	});
+
+	test("Confirm dialog can be confirmed", async (t) => {
+		let p = app.showConfirmDialogAsync((d) => {
+			d.messages = ["Foo?", "Bar?"];
+			d.confirmLabel = "Yes";
+		});
+		let dialog = await t.expectMessageDialogAsync(10, /Foo/, /Bar/);
+		await dialog.clickAsync("Yes");
+		let result = await p;
+		expect(result).toBeTruthy();
+	});
 });


### PR DESCRIPTION
This adds a new method that's useful for testing message dialog interactions in integration tests, without explicitly having to look for labels and buttons on screen.