### PR TITLE
Remove withField static method to possibly simplify i18n logic

### DIFF
--- a/packages/frame-core/src/ui/UIFormContext.ts
+++ b/packages/frame-core/src/ui/UIFormContext.ts
@@ -28,7 +28,7 @@ export const _boundFormContext = bound("formContext");
  * // Use form fields in a form
  * const FormView = UIForm.with(
  *   { formContext: bound("fooForm") },
- *   UITextField.withField("foo"),
+ *   UITextField.with({ formField: "foo" }),
  *   UILabel.with({
  *     style: myStyles.errorLabel,
  *     hidden: bound.not("fooForm.errors.foo"),
@@ -58,7 +58,7 @@ export const _boundFormContext = bound("formContext");
  * @example
  * // Use form fields with formContext on the activity
  * const MyView = UICell.with(
- *   UITextField.withField("foo"),
+ *   UITextField.with({ formField: "foo" }),
  *   // ...
  * );
  *

--- a/packages/frame-core/src/ui/controls/UITextField.ts
+++ b/packages/frame-core/src/ui/controls/UITextField.ts
@@ -1,9 +1,4 @@
-import {
-	ManagedEvent,
-	Observer,
-	StringConvertible,
-	strf,
-} from "../../base/index.js";
+import { ManagedEvent, Observer, StringConvertible } from "../../base/index.js";
 import { UIComponent } from "../UIComponent.js";
 import { UIFormContext, _boundFormContext } from "../UIFormContext.js";
 import { UITheme } from "../UITheme.js";
@@ -18,19 +13,6 @@ import { UITheme } from "../UITheme.js";
  * @online_docs Refer to the Desk website for more documentation on using this UI component class.
  */
 export class UITextField extends UIComponent {
-	/**
-	 * Creates a preset text field class with the specified form field name and placeholder
-	 * - The form field name is used with the nearest `formContext` property, see {@link UIFormContext}.
-	 * - The specified placeholder text is localized using {@link strf} before being set as {@link UITextField.placeholder}.
-	 * @param formField The form field name to use
-	 * @param placeholder The placeholder text to display when the text field is empty
-	 * @returns A class that can be used to create instances of this text field class with the provided form field name and placeholder
-	 */
-	static withField(formField?: string, placeholder?: StringConvertible) {
-		if (typeof placeholder === "string") placeholder = strf(placeholder);
-		return this.with({ formField, placeholder });
-	}
-
 	/** Creates a new text field view instance */
 	constructor(placeholder?: StringConvertible, value?: string) {
 		super();

--- a/packages/frame-core/src/ui/controls/UIToggle.ts
+++ b/packages/frame-core/src/ui/controls/UIToggle.ts
@@ -1,9 +1,4 @@
-import {
-	ManagedEvent,
-	Observer,
-	StringConvertible,
-	strf,
-} from "../../base/index.js";
+import { ManagedEvent, Observer, StringConvertible } from "../../base/index.js";
 import { UIComponent } from "../UIComponent.js";
 import { UIFormContext, _boundFormContext } from "../UIFormContext.js";
 import { UITheme } from "../UITheme.js";
@@ -18,19 +13,6 @@ import { UITheme } from "../UITheme.js";
  * @online_docs Refer to the Desk website for more documentation on using this UI component class.
  */
 export class UIToggle extends UIComponent {
-	/**
-	 * Creates a preset toggle class with the specified form field name and label
-	 * - The form field name is used with the nearest `formContext` property, see {@link UIFormContext}.
-	 * - The specified label text is localized using {@link strf} before being set as {@link UIToggle.label}.
-	 * @param formField The form field name to use
-	 * @param label The toggle label to display
-	 * @returns A class that can be used to create instances of this toggle class with the provided form field name and label
-	 */
-	static withField(formField?: string, label?: StringConvertible) {
-		if (typeof label === "string") label = strf(label);
-		return this.with({ formField: formField, label });
-	}
-
 	/** Creates a new toggle view object with the specified label */
 	constructor(label?: StringConvertible, state?: boolean) {
 		super();

--- a/packages/frame-core/test/tests/ui/form.ts
+++ b/packages/frame-core/test/tests/ui/form.ts
@@ -163,7 +163,7 @@ describe("UIForm and UIFormContext", () => {
 		let MyComp = UIFormController.with(
 			UIRow.with(
 				UILabel.withText(bound("formContext.errors.foo")),
-				UITextField.withField("foo"),
+				UITextField.with({ formField: "foo" }),
 			),
 		);
 		let view = new MyComp();
@@ -195,11 +195,11 @@ describe("UIForm and UIFormContext", () => {
 		const ViewBody = UIRow.with(
 			UIForm.with(
 				{ formContext: bound("form1") },
-				UITextField.withField("text"),
+				UITextField.with({ formField: "text" }),
 			),
 			UIForm.with(
 				{ formContext: bound("form2") },
-				UITextField.withField("text"),
+				UITextField.with({ formField: "text" }),
 			),
 		);
 		class MyActivity extends Activity {

--- a/packages/frame-core/test/tests/ui/textfield.ts
+++ b/packages/frame-core/test/tests/ui/textfield.ts
@@ -1,4 +1,4 @@
-import { UITextField, UIFormContext, app } from "../../../dist/index.js";
+import { UITextField, UIFormContext, app, strf } from "../../../dist/index.js";
 import {
 	describe,
 	expect,
@@ -24,8 +24,11 @@ describe("UITextField", (scope) => {
 		expect(tf).toHaveProperty("placeholder").asString().toBe("foo");
 	});
 
-	test("Preset using withField and form context", () => {
-		let MyTF = UITextField.withField("foo", "Placeholder");
+	test("Preset using formField and form context", () => {
+		let MyTF = UITextField.with({
+			formField: "foo",
+			placeholder: strf("Placeholder"),
+		});
 		let tf = new MyTF();
 		expect(tf).toHaveProperty("formField").toBe("foo");
 		expect(tf).toHaveProperty("placeholder").asString().toBe("Placeholder");

--- a/packages/frame-core/test/tests/ui/toggle.ts
+++ b/packages/frame-core/test/tests/ui/toggle.ts
@@ -1,4 +1,4 @@
-import { UIToggle, UIFormContext, app } from "../../../dist/index.js";
+import { UIToggle, UIFormContext, app, strf } from "../../../dist/index.js";
 import {
 	describe,
 	expect,
@@ -25,8 +25,8 @@ describe("UIToggle", (scope) => {
 		expect(toggle).toHaveProperty("state").toBe(true);
 	});
 
-	test("Preset using withField and form context", () => {
-		let MyToggle = UIToggle.withField("foo", "Foo");
+	test("Preset using form field and form context", () => {
+		let MyToggle = UIToggle.with({ formField: "foo", label: strf("Foo") });
 		let toggle = new MyToggle();
 		expect(toggle).toHaveProperty("formField").toBe("foo");
 		expect(toggle).toHaveProperty("label").asString().toBe("Foo");


### PR DESCRIPTION
Since the `withField()` method doesn't expect the (localizable) text as its _first_ parameter, it becomes nearly impossible to find strings using a gettext-like tool.

After this, translatable strings are either JSX text, or first parameters of strf, withText, or withLabel.