### PR TITLE
Rename log severity property to level

### DIFF
--- a/packages/frame-core/src/app/GlobalContext.ts
+++ b/packages/frame-core/src/app/GlobalContext.ts
@@ -398,7 +398,7 @@ export class GlobalContext extends ManagedObject {
 		f: (message: LogWriter.LogMessageData) => void,
 	) {
 		this.log.emitter.listen((e) => {
-			if (e.data.severity >= minLevel) f(e.data);
+			if (e.data.level >= minLevel) f(e.data);
 		});
 	}
 

--- a/packages/frame-core/test/tests/app/log.ts
+++ b/packages/frame-core/test/tests/app/log.ts
@@ -8,7 +8,7 @@ describe("LogWriter", (ctx) => {
 
 	test("Add log sink", () => {
 		app.addLogHandler(0, (data) => {
-			expect(data.severity).toBe(2);
+			expect(data.level).toBe(2);
 			expect(data.message).toBe("Hello");
 		});
 		app.log.information("Hello");
@@ -24,7 +24,7 @@ describe("LogWriter", (ctx) => {
 			"Fatal",
 		];
 		app.addLogHandler(2, (data) => {
-			t.count(levels[data.severity] || "Unknown");
+			t.count(levels[data.level] || "Unknown");
 		});
 		app.log.verbose("Hello");
 		app.log.debug("Hello");


### PR DESCRIPTION
This PR changes the LogMessageData `severity` property to `level` since this is the word used in the rest of the code and docs, and is a more familiar term.