### PR TITLE
Add `I18nProvider.getLocale` method

### DIFF
--- a/packages/frame-core/src/app/I18nProvider.ts
+++ b/packages/frame-core/src/app/I18nProvider.ts
@@ -3,6 +3,9 @@
  * - I18n providers are selected on the global application context. Refer to {@link GlobalContext.i18n app.i18n} for details.
  */
 export interface I18nProvider {
+	/** Returns the locale identifier, usually a combination of language and country codes */
+	getLocale(): string;
+
 	/**
 	 * A method that's used to localize a string
 	 * @summary This method is called primarily by {@link LazyString} (the result of {@link strf()}), for each string that should be translated. The implementation of this method may use a lookup table to provide a translation for a particular language, or it may return the same string if translation isn't necessary.

--- a/packages/frame-core/test/tests/app/appexception.ts
+++ b/packages/frame-core/test/tests/app/appexception.ts
@@ -50,6 +50,7 @@ describe("AppException", (scope) => {
 			constructor(public word: string) {
 				super();
 			}
+			getLocale = () => "test";
 			format = () => "";
 			getPlural = () => "";
 			getDecimalSeparator = () => ".";

--- a/packages/frame-core/test/tests/app/i18n.ts
+++ b/packages/frame-core/test/tests/app/i18n.ts
@@ -18,6 +18,9 @@ describe("I18n", (scope) => {
 	});
 
 	class BaseI18nProvider implements I18nProvider {
+		getLocale() {
+			return "test";
+		}
 		getText(text: string): string {
 			throw new Error("Method not implemented.");
 		}
@@ -27,7 +30,7 @@ describe("I18n", (scope) => {
 		format(value: any, ...types: any[]): string {
 			throw new Error("Method not implemented.");
 		}
-		getDecimalSeparator(): string {
+		getDecimalSeparator() {
 			return ".";
 		}
 	}

--- a/packages/frame-core/test/tests/ui/jsx.tsx
+++ b/packages/frame-core/test/tests/ui/jsx.tsx
@@ -7,7 +7,6 @@ import {
 import {
 	JSX,
 	LazyString,
-	ManagedObject,
 	UICell,
 	UIColor,
 	UIColumn,
@@ -186,7 +185,8 @@ describe("JSX", () => {
 		await t.expectOutputAsync(50, { text: "You have 1 email" });
 
 		// Use I18n provider for text translation (note binding path)
-		class MyI18nProvider extends ManagedObject {
+		class MyI18nProvider {
+			getLocale = () => "test";
 			getText = (s: string) =>
 				s === "You have %[numEmails:n] %[numEmails:plural|email|emails]"
 					? "Je hebt %[numEmails:n] %[numEmails:plural|e-mail|e-mails]"


### PR DESCRIPTION
This method can be used to get the locale ID, to be used with e.g. `Intl`.

The method is required since it's part of the `I18nProvider` interface, so this is a breaking change for code that has an i18n provider.