### PR TITLE
Fix: service list observer property access

### DIFF
--- a/packages/frame-core/src/app/ServiceContext.ts
+++ b/packages/frame-core/src/app/ServiceContext.ts
@@ -75,8 +75,8 @@ export class ServiceContext extends ManagedObject {
 
 	// keep track of services in a list, and forward events
 	private _map?: Map<string, Service>;
-	private _list = this.attach(new ManagedList<Service>(), () => {
-		this._map = new Map(this._list.map((s) => [s.id, s]));
+	private _list = this.attach(new ManagedList<Service>(), (list) => {
+		this._map = new Map(list?.map((s) => [s.id, s]));
 		this.emitChange();
 	});
 }


### PR DESCRIPTION
The attach callback function (observer) was using the attached `_list` property on the object, but should have been using its own parameter instead. When the list is initially created, the callback is called before the property is set.