### PR TITLE
Add variant presets and some additional styles

### DIFF
--- a/packages/frame-core/src/app/ViewComposite.ts
+++ b/packages/frame-core/src/app/ViewComposite.ts
@@ -4,7 +4,7 @@ import {
 	ManagedObject,
 	Observer,
 } from "../base/index.js";
-import { ERROR, err, errorHandler } from "../errors.js";
+import { ERROR, err, errorHandler, invalidArgErr } from "../errors.js";
 import { RenderContext } from "./RenderContext.js";
 import { View, ViewClass } from "./View.js";
 
@@ -67,7 +67,12 @@ export abstract class ViewComposite<TView extends View = View> extends View {
 			constructor(preset: any, ...content: TContent) {
 				super();
 				this._Content = content;
-				this.applyViewPreset({ ...defaults, ...preset });
+				if (preset?.variant && !(this instanceof preset.variant.type)) {
+					throw invalidArgErr("preset.variant");
+				}
+				let apply = { ...defaults, ...preset?.variant?.preset, ...preset };
+				delete apply.variant;
+				this.applyViewPreset(apply);
 			}
 			protected override createView() {
 				return ViewBody
@@ -213,14 +218,47 @@ export namespace ViewComposite {
 	> = {
 		/** Creates an instance of this view composite */
 		new (
-			preset?: TPreset,
+			preset?: TPreset & {
+				/** A view composite variant object, applied before other presets */
+				variant?: ViewCompositeVariant<TPreset, TObject>;
+			},
 			...content: TContent
 		): ViewComposite<TBodyView> & TObject;
 
 		/** Creates a preset class that further extends this view composite */
 		preset(
-			preset?: TPreset,
+			preset?: TPreset & {
+				/** A view composite variant object, applied before other presets */
+				variant?: ViewCompositeVariant<TPreset, TObject>;
+			},
 			...content: TContent
 		): { new (): ViewComposite<TBodyView> & TObject };
 	};
+}
+
+/**
+ * An object that includes predefined properties for a view composite
+ * - View composite variants can be used for the `variant` property passed to a view composite constructor, in JSX tags and with the static `preset` method.
+ * - Variants can only be used with a specific view composite class, and sub classes.
+ * - To create a new variant for a UI component instead, use {@link UIVariant}.
+ */
+export class ViewCompositeVariant<TPreset, TObject> {
+	/**
+	 * Creates a new view composite variant object
+	 * - The resulting instance can be used for the `variant` property passed to a view composite constructor, in JSX tags and with the static `preset` method.
+	 * @param type The view composite class that the variant will be used with
+	 * @param preset The properties, bindings, and event handlers that will be preset on each object created with this variant
+	 */
+	constructor(
+		public readonly type: ViewComposite.WithPreset<
+			TPreset,
+			any[],
+			View,
+			TObject
+		>,
+		public readonly preset: Readonly<TPreset>,
+	) {
+		this.type = type;
+		this.preset = Object.freeze({ ...preset });
+	}
 }

--- a/packages/frame-core/src/ui/UIVariant.ts
+++ b/packages/frame-core/src/ui/UIVariant.ts
@@ -1,0 +1,28 @@
+import type { View } from "../app/index.js";
+import { invalidArgErr } from "../errors.js";
+import { UIComponent } from "./UIComponent.js";
+
+/**
+ * An object that includes predefined properties for a UI component
+ * - UI component variants can be used with `ui` functions such as `ui.button(...)`, and in JSX tags for UI controls and containers.
+ * - Variants can only be used with a specific UI component class, e.g. {@link UIButton}.
+ * - To create a new variant for a view composite instead, use {@link ViewCompositeVariant}.
+ */
+export class UIVariant<T extends UIComponent> {
+	/**
+	 * Creates a new UI component variant object
+	 * - The resulting instance can be used with `ui` functions such as `ui.button(...)`, and in JSX tags for UI controls and containers.
+	 * @param type The UI component class that the variant will be used with, e.g {@link UIButton}
+	 * @param preset The properties, bindings, and event handlers that will be preset on each object created with this variant
+	 */
+	constructor(
+		public readonly type: new () => T,
+		public readonly preset: Readonly<View.ViewPreset<T>>,
+	) {
+		if (!(type.prototype instanceof UIComponent)) {
+			throw invalidArgErr("type");
+		}
+		this.type = type;
+		this.preset = Object.freeze({ ...preset });
+	}
+}

--- a/packages/frame-core/src/ui/index.ts
+++ b/packages/frame-core/src/ui/index.ts
@@ -1,4 +1,5 @@
 export * from "./UIStyle.js";
+export * from "./UIVariant.js";
 export * from "./UITheme.js";
 export * from "./UIColor.js";
 export * from "./UIIconResource.js";

--- a/packages/frame-core/src/ui/ui_interface.ts
+++ b/packages/frame-core/src/ui/ui_interface.ts
@@ -1,9 +1,11 @@
 import type { RenderContext, View, ViewClass } from "../app/index.js";
 import type { Binding, BindingOrValue, LazyString } from "../base/index.js";
 import type { UIColor } from "./UIColor.js";
+import { UIComponent } from "./UIComponent.js";
 import type { UIIconResource } from "./UIIconResource.js";
 import { UIStyle } from "./UIStyle.js";
 import type { UITheme } from "./UITheme.js";
+import { UIVariant } from "./UIVariant.js";
 import type { UIAnimationView } from "./composites/UIAnimationView.js";
 import type { UIConditionalView } from "./composites/UIConditionalView.js";
 import type { UIListView } from "./composites/UIListView.js";
@@ -26,23 +28,35 @@ import type { UIToggle } from "./controls/UIToggle.js";
  */
 export const ui: Readonly<ui> = Object.create(null) as any;
 export namespace ui {
+	/**
+	 * Type definition for a UI component preset object
+	 * - This type is used to define the properties, bindings, and event handlers that can be preset on UI components using functions such as `ui.button(...)`.
+	 * - The `variant` property can be used to specify a {@link UIVariant} object.
+	 * @see {@link View.ViewPreset}
+	 * @see {@link UIVariant}
+	 */
+	export type PresetType<T extends UIComponent> = View.ViewPreset<T> & {
+		/** A UI component variant object, applied before other presets */
+		variant?: UIVariant<T>;
+	};
+
 	/** Type definition for using {@link ui.jsx} */
 	export namespace JSX {
 		export type Element = ViewClass;
 		export interface IntrinsicElements {
-			cell: View.ViewPreset<UICell>;
-			column: View.ViewPreset<UIColumn>;
-			row: View.ViewPreset<UIRow>;
-			form: View.ViewPreset<UIForm>;
-			scroll: View.ViewPreset<UIScrollContainer>;
-			animatedcell: View.ViewPreset<UIAnimatedCell>;
-			label: View.ViewPreset<UILabel>;
-			button: View.ViewPreset<UIButton>;
-			textfield: View.ViewPreset<UITextField>;
-			toggle: View.ViewPreset<UIToggle>;
-			separator: View.ViewPreset<UISeparator>;
-			spacer: View.ViewPreset<UISpacer>;
-			image: View.ViewPreset<UIImage>;
+			cell: ui.PresetType<UICell>;
+			column: ui.PresetType<UIColumn>;
+			row: ui.PresetType<UIRow>;
+			form: ui.PresetType<UIForm>;
+			scroll: ui.PresetType<UIScrollContainer>;
+			animatedcell: ui.PresetType<UIAnimatedCell>;
+			label: ui.PresetType<UILabel>;
+			button: ui.PresetType<UIButton>;
+			textfield: ui.PresetType<UITextField>;
+			toggle: ui.PresetType<UIToggle>;
+			separator: ui.PresetType<UISeparator>;
+			spacer: ui.PresetType<UISpacer>;
+			image: ui.PresetType<UIImage>;
 			render: View.ViewPreset<UIViewRenderer>;
 			animate: View.ViewPreset<UIAnimationView>;
 			conditional: View.ViewPreset<UIConditionalView>;
@@ -76,7 +90,7 @@ export interface ui {
 	 * @param content The content that will be added to each instance of the resulting class
 	 * @returns A new class that extends {@link UICell}
 	 */
-	cell(preset: View.ViewPreset<UICell>, content?: ViewClass): ViewClass<UICell>;
+	cell(preset: ui.PresetType<UICell>, content?: ViewClass): ViewClass<UICell>;
 	cell(content: ViewClass): ViewClass<UICell>;
 
 	/**
@@ -86,7 +100,7 @@ export interface ui {
 	 * @returns A new class that extends {@link UIColumn}
 	 */
 	column(
-		preset: View.ViewPreset<UIColumn>,
+		preset: ui.PresetType<UIColumn>,
 		...content: ViewClass[]
 	): ViewClass<UIColumn>;
 	column(...content: ViewClass[]): ViewClass<UIColumn>;
@@ -97,10 +111,7 @@ export interface ui {
 	 * @param content The content that will be added to each instance of the resulting class
 	 * @returns A new class that extends {@link UIRow}
 	 */
-	row(
-		preset: View.ViewPreset<UIRow>,
-		...content: ViewClass[]
-	): ViewClass<UIRow>;
+	row(preset: ui.PresetType<UIRow>, ...content: ViewClass[]): ViewClass<UIRow>;
 	row(...content: ViewClass[]): ViewClass<UIRow>;
 
 	/**
@@ -110,7 +121,7 @@ export interface ui {
 	 * @returns A new class that extends {@link UIForm}
 	 */
 	form(
-		preset: View.ViewPreset<UIForm>,
+		preset: ui.PresetType<UIForm>,
 		...content: ViewClass[]
 	): ViewClass<UIForm>;
 	form(...content: ViewClass[]): ViewClass<UIForm>;
@@ -122,7 +133,7 @@ export interface ui {
 	 * @returns A new class that extends {@link UIScrollContainer}
 	 */
 	scroll(
-		preset: View.ViewPreset<UIScrollContainer>,
+		preset: ui.PresetType<UIScrollContainer>,
 		...content: ViewClass[]
 	): ViewClass<UIScrollContainer>;
 	scroll(...content: ViewClass[]): ViewClass<UIScrollContainer>;
@@ -134,7 +145,7 @@ export interface ui {
 	 * @returns A new class that extends {@link UIAnimatedCell}
 	 */
 	animatedCell(
-		preset: View.ViewPreset<UIAnimatedCell>,
+		preset: ui.PresetType<UIAnimatedCell>,
 		content?: ViewClass,
 	): ViewClass<UIAnimatedCell>;
 
@@ -145,10 +156,14 @@ export interface ui {
 	 * @param style Preset label style (optional)
 	 * @returns A new class that extends {@link UILabel}
 	 */
-	label(preset: View.ViewPreset<UILabel>): ViewClass<UILabel>;
+	label(
+		preset: ui.PresetType<UILabel>,
+		text?: BindingOrValue<string | LazyString>,
+		style?: UIVariant<UILabel> | UIStyle.TypeOrOverrides<UILabel.StyleType>,
+	): ViewClass<UILabel>;
 	label(
 		text?: BindingOrValue<string | LazyString>,
-		style?: UIStyle.TypeOrOverrides<UILabel.StyleType>,
+		style?: UIVariant<UILabel> | UIStyle.TypeOrOverrides<UILabel.StyleType>,
 	): ViewClass<UILabel>;
 
 	/**
@@ -159,11 +174,16 @@ export interface ui {
 	 * @param style Preset button style (optional)
 	 * @returns A new class that extends {@link UILabel}
 	 */
-	button(preset: View.ViewPreset<UIButton>): ViewClass<UIButton>;
+	button(
+		preset: ui.PresetType<UIButton>,
+		label?: BindingOrValue<string | LazyString>,
+		onClick?: string,
+		style?: UIVariant<UIButton> | UIStyle.TypeOrOverrides<UIButton.StyleType>,
+	): ViewClass<UIButton>;
 	button(
 		label?: BindingOrValue<string | LazyString>,
 		onClick?: string,
-		style?: UIStyle.TypeOrOverrides<UIButton.StyleType>,
+		style?: UIVariant<UIButton> | UIStyle.TypeOrOverrides<UIButton.StyleType>,
 	): ViewClass<UIButton>;
 
 	/**
@@ -171,21 +191,21 @@ export interface ui {
 	 * @param preset The properties, bindings, and event handlers that will be preset on each instance of the resulting class
 	 * @returns A new class that extends {@link UITextField}
 	 */
-	textField(preset: View.ViewPreset<UITextField>): ViewClass<UITextField>;
+	textField(preset: ui.PresetType<UITextField>): ViewClass<UITextField>;
 
 	/**
 	 * Creates a preset {@link UIToggle} constructor using the provided options
 	 * @param preset The properties, bindings, and event handlers that will be preset on each instance of the resulting class
 	 * @returns A new class that extends {@link UIToggle}
 	 */
-	toggle(preset: View.ViewPreset<UIToggle>): ViewClass<UIToggle>;
+	toggle(preset: ui.PresetType<UIToggle>): ViewClass<UIToggle>;
 
 	/**
 	 * Creates a preset {@link UISeparator} constructor using the provided options
 	 * @param preset The properties, bindings, and event handlers that will be preset on each instance of the resulting class
 	 * @returns A new class that extends {@link UISeparator}
 	 */
-	separator(preset?: View.ViewPreset<UISeparator>): ViewClass<UISeparator>;
+	separator(preset?: ui.PresetType<UISeparator>): ViewClass<UISeparator>;
 
 	/**
 	 * Creates a preset {@link UISpacer} constructor using the provided options
@@ -196,26 +216,18 @@ export interface ui {
 	 * @param minHeight Preset spacer minimum height
 	 * @returns A new class that extends {@link UISpacer}
 	 */
-	spacer(preset: View.ViewPreset<UISpacer>): ViewClass<UISpacer>;
+	spacer(preset: ui.PresetType<UISpacer>): ViewClass<UISpacer>;
 	spacer(
 		width?: number | string,
 		height?: number | string,
-		minWidth?: number | string,
-		minHeight?: number | string,
 	): ViewClass<UISpacer>;
 
 	/**
 	 * Creates a preset {@link UIImage} constructor using the provided options
 	 * @param preset The properties, bindings, and event handlers that will be preset on each instance of the resulting class
-	 * @param url Preset image URL
-	 * @param style Preset image style (optional)
 	 * @returns A new class that extends {@link UIImage}
 	 */
-	image(preset: View.ViewPreset<UIImage>): ViewClass<UIImage>;
-	image(
-		url: string,
-		style?: UIStyle.TypeOrOverrides<UIImage.StyleType>,
-	): ViewClass<UIImage>;
+	image(preset: ui.PresetType<UIImage>): ViewClass<UIImage>;
 
 	/**
 	 * Creates a preset {@link UIViewRenderer} constructor using the provided options
@@ -266,6 +278,7 @@ export interface ui {
 	/**
 	 * A function that returns a new UIColor instance for the specified theme color
 	 * - Colors can be defined using {@link UITheme.colors}.
+	 * @see {@link UIColor}
 	 */
 	color: {
 		(name: string): UIColor;
@@ -306,8 +319,9 @@ export interface ui {
 	};
 
 	/**
-	 * A function that returns a new UIIconResource instance for the specified icon
+	 * A function that returns a new icon resource object for the specified icon
 	 * - Icons can be defined using {@link UITheme.icons}.
+	 * @see {@link UIIconResource}
 	 */
 	icon: {
 		(name: string): UIIconResource;
@@ -327,6 +341,7 @@ export interface ui {
 	/**
 	 * A function that returns an animation defined by the current theme
 	 * - Animations can be defined using {@link UITheme.animations}.
+	 * @see {@link RenderContext.OutputTransformer}
 	 */
 	animation: {
 		(name: string): RenderContext.OutputTransformer;
@@ -349,6 +364,7 @@ export interface ui {
 	/**
 	 * A function that returns a (cell) output effect defined by the current theme
 	 * - Effects can be defined using {@link UITheme.effects}.
+	 * @see {@link RenderContext.OutputEffect}
 	 */
 	effect: {
 		(name: string): RenderContext.OutputEffect;
@@ -360,6 +376,7 @@ export interface ui {
 	/**
 	 * A function that returns a new or existing UIStyle (base) class for the specified style
 	 * - Styles for each class can be defined using {@link UITheme.styles}.
+	 * @see {@link UIStyle}
 	 */
 	style: {
 		(name: string): UIStyle.Type<any>;
@@ -373,6 +390,8 @@ export interface ui {
 		readonly BUTTON_PRIMARY: UIStyle.Type<UIButton.StyleType>;
 		readonly BUTTON_PLAIN: UIStyle.Type<UIButton.StyleType>;
 		readonly BUTTON_ICON: UIStyle.Type<UIButton.StyleType>;
+		readonly BUTTON_DANGER: UIStyle.Type<UIButton.StyleType>;
+		readonly BUTTON_SUCCESS: UIStyle.Type<UIButton.StyleType>;
 		readonly TEXTFIELD: UIStyle.Type<UITextField.StyleType>;
 		readonly TOGGLE: UIStyle.Type<UIToggle.StyleType>;
 		readonly TOGGLE_LABEL: UIStyle.Type<UILabel.StyleType>;

--- a/packages/frame-core/test/tests/ui/button.ts
+++ b/packages/frame-core/test/tests/ui/button.ts
@@ -38,6 +38,13 @@ describe("UIButton", (scope) => {
 		expect(button).toHaveProperty("label").asString().toBe("foo");
 	});
 
+	test("Preset using object and label", () => {
+		let MyButton = ui.button({ accessibleLabel: "test" }, "foo");
+		let button = new MyButton();
+		expect(button).toHaveProperty("accessibleLabel").toBe("test");
+		expect(button).toHaveProperty("label").asString().toBe("foo");
+	});
+
 	test("Preset with +Event:target", () => {
 		let MyButton = ui.button({ label: "foo", onClick: "+Test:foo" });
 		let button = new MyButton();

--- a/packages/frame-core/test/tests/ui/focus.ts
+++ b/packages/frame-core/test/tests/ui/focus.ts
@@ -49,7 +49,7 @@ describe("Focus management", (scope) => {
 
 	test("Focus requests", async (t) => {
 		let MyCell = ui.cell(
-			ui.button({ requestFocus: true, label: "first" }),
+			ui.button({ requestFocus: true }, "first"),
 			ui.button("second"),
 		);
 

--- a/packages/frame-core/test/tests/ui/image.ts
+++ b/packages/frame-core/test/tests/ui/image.ts
@@ -18,12 +18,6 @@ describe("UIImage", (scope) => {
 		expect(image).toHaveProperty("url").asString().toBe("foo.png");
 	});
 
-	test("Preset using url", () => {
-		let MyImage = ui.image("foo.png");
-		let image = new MyImage();
-		expect(image).toHaveProperty("url").asString().toBe("foo.png");
-	});
-
 	test("Preset with properties", () => {
 		let MyImage = ui.image({ url: "foo.png" });
 		let image = new MyImage();

--- a/packages/frame-core/test/tests/ui/jsx.tsx
+++ b/packages/frame-core/test/tests/ui/jsx.tsx
@@ -11,6 +11,7 @@ import {
 	UIColumn,
 	UILabel,
 	ViewComposite,
+	ViewCompositeVariant,
 	app,
 	bound,
 	strf,
@@ -87,6 +88,59 @@ describe("JSX", () => {
 		let cell = new MyCell() as UICell;
 		expect(cell.content).asArray().toBeArray(1);
 		expect(cell.content.first()).toHaveProperty("foo").toBe(123);
+	});
+
+	test("Custom view composite with variant", () => {
+		const MyView = ViewComposite.withPreset(
+			{
+				/** A single property, not used in view */
+				foo: 0,
+			},
+			<label>test</label>,
+		);
+		let myViewVariant = new ViewCompositeVariant(MyView, { foo: 123 });
+		let MyCell = (
+			<cell>
+				<MyView variant={myViewVariant} />
+			</cell>
+		);
+		let cell = new MyCell() as UICell;
+		expect(cell.content).asArray().toBeArray(1);
+		expect(cell.content.first()).toHaveProperty("foo").toBe(123);
+		expect(() => {
+			const OtherView = ViewComposite.withPreset({});
+			let otherVariant = new ViewCompositeVariant(OtherView, {});
+			return new (
+				<cell>
+					<MyView variant={otherVariant} />
+				</cell>
+			)();
+		})
+			.toThrowError()
+			.asString()
+			.toMatchRegExp(/variant/);
+	});
+
+	test("Custom view composite as class, with variant", () => {
+		class MyViewComp extends ViewComposite.withPreset(
+			{
+				/** A single property, not used in view */
+				foo: 0,
+			},
+			<label>test</label>,
+		) {
+			onClick() {
+				// ...
+			}
+		}
+		let TestView = <MyViewComp foo={123} />;
+		let view = new TestView() as MyViewComp;
+		expect(view).toHaveProperty("foo").toBe(123);
+
+		let testVariant = new ViewCompositeVariant(MyViewComp, { foo: 456 });
+		let TestVariantView = <MyViewComp variant={testVariant} />;
+		let variantView = new TestVariantView() as MyViewComp;
+		expect(variantView).toHaveProperty("foo").toBe(456);
 	});
 
 	test("Custom view composite with column content", (t) => {

--- a/packages/frame-core/test/tests/ui/label.ts
+++ b/packages/frame-core/test/tests/ui/label.ts
@@ -4,7 +4,15 @@ import {
 	test,
 	useTestContext,
 } from "@desk-framework/frame-test";
-import { app, ui, UICell, UILabel, UIRow } from "../../../dist/index.js";
+import {
+	app,
+	ui,
+	UIButton,
+	UICell,
+	UILabel,
+	UIRow,
+} from "../../../dist/index.js";
+import { UIVariant } from "../../../dist/ui/UIVariant.js";
 
 describe("UILabel", (scope) => {
 	scope.beforeEach(() => {
@@ -45,6 +53,23 @@ describe("UILabel", (scope) => {
 		let MyLabel = ui.label("foo");
 		let label = new MyLabel();
 		expect(label).toHaveProperty("text").asString().toBe("foo");
+	});
+
+	test("Preset using object and text", () => {
+		let MyLabel = ui.label({ bold: true }, "foo");
+		let label = new MyLabel();
+		expect(label).toHaveProperty("bold").toBeTruthy();
+		expect(label).toHaveProperty("text").asString().toBe("foo");
+	});
+
+	test("Preset using variant", () => {
+		let MyLabel = ui.label("foo", new UIVariant(UILabel, { bold: true }));
+		let label = new MyLabel();
+		expect(label).toHaveProperty("bold").toBeTruthy();
+		expect(label).toHaveProperty("text").asString().toBe("foo");
+		expect(() => {
+			ui.label({ variant: new UIVariant(UIButton, {}) as any });
+		}).toThrowError();
 	});
 
 	test("Rendered with text", async (t) => {

--- a/packages/frame-web/src/style/Dialog.ts
+++ b/packages/frame-web/src/style/Dialog.ts
@@ -1,7 +1,8 @@
 import {
 	RenderContext,
-	UIComponent,
+	UICell,
 	UITheme,
+	UIVariant,
 	View,
 	ViewComposite,
 	app,
@@ -12,28 +13,25 @@ import {
 /**
  * A class that defines the styles for the default modal dialog view
  * - A default instance of this class is created, and can be modified in the {@link WebContextOptions} configuration callback passed to {@link useWebContext}.
- * - These styles are used by the default message dialog view referenced by the {@link UITheme} implementation — and therefore also by {@link GlobalContext.showAlertDialogAsync app.showAlertDialogAsync()} and {@link GlobalContext.showConfirmDialogAsync app.showConfirmDialogAsync()}.
+ * - These styles are used for dialog views created by the {@link GlobalContext.showDialogAsync app.showDialogAsync()} function. Note that message dialog styles are configured separately using {@link MessageDialogStyles}.
  */
 export class DialogStyles {
 	/**
-	 * The cell style used for the outer dialog container
-	 * - The default style is based on `ui.style.CELL_BG` and includes properties for dimensions and border radius
+	 * The cell variant (and style) used for the outer dialog container
+	 * - The default style is based on `ui.style.CELL_BG` and includes properties for dimensions and border radius.
+	 * - Margin is set to `auto` to center the dialog on the screen if possible.
+	 * - An `Elevate` effect is applied to add a drop shadow to the dialog.
 	 */
-	ContainerStyle = ui.style.CELL_BG.extend({
-		width: "auto",
-		minWidth: 360,
-		grow: 0,
-		borderRadius: 12,
+	containerVariant = new UIVariant(UICell, {
+		margin: "auto",
+		effect: ui.effect.ELEVATE,
+		style: ui.style.CELL_BG.extend({
+			width: "auto",
+			minWidth: 360,
+			grow: 0,
+			borderRadius: 12,
+		}),
 	});
-
-	/**
-	 * The margin that is set on the outer dialog container, to position the dialog on the screen
-	 * - By default, the dialog is centered on the screen using `auto` margins all around
-	 */
-	margin: UIComponent.Offsets = "auto";
-
-	/** The output effect that is applied to the outer dialog container, defaults to Elevate */
-	effect: RenderContext.OutputEffect = ui.effect.ELEVATE;
 }
 
 /** @internal Default modal dialog view; shown synchronously, removed when view is unlinked */
@@ -47,9 +45,7 @@ export class Dialog extends ViewComposite implements UITheme.DialogController {
 	protected override createView() {
 		return new (ui.cell(
 			{
-				style: Dialog.styles.ContainerStyle,
-				margin: Dialog.styles.margin,
-				effect: Dialog.styles.effect,
+				variant: Dialog.styles.containerVariant,
 			},
 			ui.renderView({
 				view: bound("dialogView"),

--- a/packages/frame-web/src/style/MessageDialog.ts
+++ b/packages/frame-web/src/style/MessageDialog.ts
@@ -2,9 +2,10 @@ import {
 	MessageDialogOptions,
 	RenderContext,
 	StringConvertible,
-	UIComponent,
+	UICell,
 	UIContainer,
 	UITheme,
+	UIVariant,
 	ViewComposite,
 	app,
 	strf,
@@ -15,101 +16,51 @@ import {
  * A class that defines the styles for the default modal message dialog view
  * - A default instance of this class is created, and can be modified in the {@link WebContextOptions} configuration callback passed to {@link useWebContext}.
  * - These styles are used by the default message dialog view referenced by the {@link UITheme} implementation — and therefore also by {@link GlobalContext.showAlertDialogAsync app.showAlertDialogAsync()} and {@link GlobalContext.showConfirmDialogAsync app.showConfirmDialogAsync()}.
- * - The default dialog view includes an outer container, a block of message labels, and a block of buttons. These can be customized using {@link ContainerStyle}, {@link MessageCellStyle}, and {@link ButtonCellStyle}, respectively.
+ * - The default dialog view includes an outer container, a block of message labels, and a block of buttons.
  *
  * @see {@link WebContextOptions}
  * @see {@link UITheme.ModalControllerFactory}
- *
- * @example
- * useWebContext((options) => {
- * options.messageDialogStyles.ContainerStyle =
- *   options.messageDialogStyles.ContainerStyle.extend({
- *     width: 320,
- *   });
- * options.messageDialogStyles.ButtonCellStyle =
- *   options.messageDialogStyles.ButtonCellStyle.extend({
- *     padding: { x: 32, y: 24 },
- *   });
- * });
- * options.messageDialogStyles.buttonRowLayout = {
- *   axis: "vertical",
- *   gravity: "stretch",
- *   separator: { space: 8 },
- * };
- * options.messageDialogStyles.reverseButtons = false;
  */
 export class MessageDialogStyles {
 	/**
-	 * The cell style used for the outer dialog container
-	 * - The default style includes properties for dimensions, background, border radius, and drop shadow
+	 * The cell variant (and style) used for the outer dialog container
+	 * - The default style is based on `ui.style.CELL_BG` and includes properties for dimensions and border radius.
+	 * - Margin is set to `auto` to center the dialog on the screen if possible.
+	 * - An `Elevate` effect is applied to add a drop shadow to the dialog.
 	 */
-	ContainerStyle = ui.style.CELL_BG.extend({
-		width: "auto",
-		minWidth: 360,
-		maxWidth: "95vw",
-		borderRadius: 12,
-		grow: 0,
+	containerVariant = new UIVariant(UICell, {
+		accessibleRole: "alertdialog",
+		margin: "auto",
+		effect: ui.effect.ELEVATE,
+		style: ui.style.CELL_BG.extend({
+			width: "auto",
+			minWidth: 360,
+			maxWidth: "95vw",
+			grow: 0,
+			borderRadius: 12,
+		}),
 	});
 
 	/**
-	 * The margin that is set on the outer dialog container, to position the dialog on the screen
-	 * - By default, the dialog is centered on the screen using `auto` margins all around
+	 * The cell variant used for the block of messages
+	 * - The default style only includes padding. A `DragModal` effect is applied to the container to use the cell as a grab handle for the entire dialog.
 	 */
-	margin: UIComponent.Offsets = "auto";
-
-	/** The output effect that is applied to the outer dialog container, defaults to Elevate */
-	effect: RenderContext.OutputEffect = ui.effect.ELEVATE;
-
-	/**
-	 * The cell style used for the block of messages
-	 * - The default style only includes padding
-	 */
-	MessageCellStyle = ui.style.CELL.extend({
-		padding: 16,
+	messageCellVariant = new UIVariant(UICell, {
+		effect: ui.effect("DragModal"),
+		style: ui.style.CELL.extend({
+			padding: 16,
+		}),
 	});
 
 	/**
-	 * The cell style used for the block of buttons
+	 * The cell variant used for the block of buttons
 	 * - The default style includes properties for padding and background
 	 */
-	ButtonCellStyle = ui.style.CELL.extend({
-		padding: 16,
+	buttonCellVariant = new UIVariant(UICell, {
+		style: ui.style.CELL.extend({
+			padding: 16,
+		}),
 	});
-
-	/**
-	 * The label style used for the first message label
-	 * - The default style includes centered, bold text, with a maximum width of 480 pixels.
-	 */
-	FirstLabelStyle = ui.style.LABEL.extend({
-		bold: true,
-		textAlign: "center",
-		maxWidth: 480,
-		lineBreakMode: "pre-wrap",
-		userSelect: true,
-	});
-
-	/**
-	 * The label style used for all labels except the first
-	 * - The default style includes centered text, with a maximum width of 480 pixels.
-	 */
-	LabelStyle = ui.style.LABEL.extend({
-		textAlign: "center",
-		maxWidth: 480,
-		lineBreakMode: "pre-wrap",
-		userSelect: true,
-	});
-
-	/**
-	 * The button style used for all buttons except the confirm button
-	 * - This property defaults to the default button style.
-	 */
-	ButtonStyle = ui.style.BUTTON;
-
-	/**
-	 * The button style used for the confirm button
-	 * - This property defaults to the default primary button style.
-	 */
-	ConfirmButtonStyle = ui.style.BUTTON_PRIMARY;
 
 	/**
 	 * Options for the layout of the row of buttons
@@ -125,6 +76,41 @@ export class MessageDialogStyles {
 	 * - This property defaults to true, which means that the confirm button is displayed last. Set to false to display the confirm button first.
 	 */
 	reverseButtons = true;
+
+	/**
+	 * The label style used for the first message label
+	 * - The default style includes centered, bold text, with a maximum width of 480 pixels.
+	 */
+	firstLabelStyle = ui.style.LABEL.extend({
+		bold: true,
+		textAlign: "center",
+		maxWidth: 480,
+		lineBreakMode: "pre-wrap",
+		userSelect: true,
+	});
+
+	/**
+	 * The label style used for all labels except the first
+	 * - The default style includes centered text, with a maximum width of 480 pixels.
+	 */
+	labelStyle = ui.style.LABEL.extend({
+		textAlign: "center",
+		maxWidth: 480,
+		lineBreakMode: "pre-wrap",
+		userSelect: true,
+	});
+
+	/**
+	 * The button style used for all buttons except the confirm button
+	 * - This property defaults to the default button style.
+	 */
+	buttonStyle = ui.style.BUTTON;
+
+	/**
+	 * The button style used for the confirm button
+	 * - This property defaults to the default primary button style.
+	 */
+	confirmButtonStyle = ui.style.BUTTON_PRIMARY;
 }
 
 /** @internal Default modal message dialog view; shown asynchronously and resolves a promise */
@@ -175,28 +161,28 @@ export class MessageDialog
 
 	protected override createView() {
 		let messageLabels = this.options.messages.map((text, i) =>
-			ui.label({
-				style: i
-					? MessageDialog.styles.LabelStyle
-					: MessageDialog.styles.FirstLabelStyle,
-				text,
-			}),
+			ui.label(
+				String(text),
+				i
+					? MessageDialog.styles.labelStyle
+					: MessageDialog.styles.firstLabelStyle,
+			),
 		);
 		let buttons = [
 			ui.button({
-				style: MessageDialog.styles.ConfirmButtonStyle,
+				style: MessageDialog.styles.confirmButtonStyle,
 				label: this.confirmLabel,
 				onClick: "+Confirm",
 				requestFocus: true,
 			}),
 			ui.button({
-				style: MessageDialog.styles.ButtonStyle,
+				style: MessageDialog.styles.buttonStyle,
 				hidden: !this.otherLabel,
 				label: this.otherLabel,
 				onClick: "+Other",
 			}),
 			ui.button({
-				style: MessageDialog.styles.ButtonStyle,
+				style: MessageDialog.styles.buttonStyle,
 				hidden: !this.cancelLabel,
 				label: this.cancelLabel,
 				onClick: "+Cancel",
@@ -204,24 +190,14 @@ export class MessageDialog
 		];
 		if (MessageDialog.styles.reverseButtons) buttons.reverse();
 		return new (ui.cell(
-			{
-				style: MessageDialog.styles.ContainerStyle,
-				margin: MessageDialog.styles.margin,
-				effect: MessageDialog.styles.effect,
-				accessibleRole: "alertdialog",
-			},
+			{ variant: MessageDialog.styles.containerVariant },
 			ui.column(
 				ui.cell(
-					{
-						style: MessageDialog.styles.MessageCellStyle,
-						effect: ui.effect("DragModal"),
-					},
+					{ variant: MessageDialog.styles.messageCellVariant },
 					ui.column(...messageLabels),
 				),
 				ui.cell(
-					{
-						style: MessageDialog.styles.ButtonCellStyle,
-					},
+					{ variant: MessageDialog.styles.buttonCellVariant },
 					ui.row({ layout: MessageDialog.styles.buttonRowLayout }, ...buttons),
 				),
 			),

--- a/packages/frame-web/src/style/WebTheme.ts
+++ b/packages/frame-web/src/style/WebTheme.ts
@@ -22,6 +22,9 @@ import { icons } from "./defaults/icons.js";
 import { defaultControlTextStyle, styles } from "./defaults/styles.js";
 import { Dialog } from "./Dialog.js";
 
+let _pxScaleOverride: number | undefined;
+let _importedCSS: string[] = [];
+
 /** @internal Modal view implementation for the web context */
 export class ModalFactory implements UITheme.ModalControllerFactory {
 	buildDialog(view: View) {
@@ -44,8 +47,8 @@ export class WebTheme extends UITheme {
 	static initializeCSS(options: WebContextOptions) {
 		resetCSS();
 		setGlobalCSS(makeBaseCSS());
-		setLogicalPxScale(options.logicalPxScale);
-		importStylesheets(options.importCSS);
+		setLogicalPxScale(_pxScaleOverride ?? options.logicalPxScale);
+		importStylesheets([...options.importCSS, ..._importedCSS]);
 		setControlTextStyle({
 			...defaultControlTextStyle,
 			...options.controlTextStyle,
@@ -55,8 +58,12 @@ export class WebTheme extends UITheme {
 		}
 	}
 
-	/** Imports an additional set of style sheets from the provided list of URLs */
+	/**
+	 * Imports an additional set of style sheets from the provided list of URLs
+	 * @note Stylesheets can also be imported using the options callback provided to {@link useWebContext()}.
+	 */
 	static importStylesheets(urls: string[]) {
+		_importedCSS.push(...urls);
 		importStylesheets(urls);
 	}
 
@@ -65,6 +72,7 @@ export class WebTheme extends UITheme {
 	 * @note This value can also be set using the options callback provided to {@link useWebContext()}.
 	 */
 	static setLogicalPxScale(scale: number) {
+		_pxScaleOverride = scale;
 		setLogicalPxScale(scale);
 	}
 

--- a/packages/frame-web/src/style/defaults/styles.ts
+++ b/packages/frame-web/src/style/defaults/styles.ts
@@ -1,4 +1,4 @@
-import { UIComponent, UIStyle, ui } from "@desk-framework/frame-core";
+import { UIColor, UIComponent, UIStyle, ui } from "@desk-framework/frame-core";
 
 type CombinedStyleType = UIComponent.DimensionsStyleType &
 	UIComponent.DecorationStyleType &
@@ -15,7 +15,6 @@ export const defaultControlTextStyle: CombinedStyleType = {
 
 const _color_clear = ui.color.CLEAR;
 const _color_text = ui.color.TEXT;
-const _color_primaryBackground = ui.color.PRIMARY_BG;
 const _color_controlBase = ui.color.CONTROL_BASE;
 
 const baseButtonStyle: CombinedStyleType = {
@@ -63,6 +62,15 @@ const pressedNotDisabled: CombinedStyleType = {
 	[UIStyle.STATE_DISABLED]: false,
 };
 
+function makeBgButtonStyle(bg: UIColor) {
+	return [
+		{ ...baseButtonStyle, background: bg, textColor: bg.text() },
+		{ ...hoveredNotDisabled, background: bg.contrast(0.2) },
+		{ ...pressedNotDisabled, background: bg.contrast(-0.1) },
+		disabledStyle,
+	];
+}
+
 /** @internal Default styles for `UITheme.styles` */
 export const styles: [
 	name: string,
@@ -96,25 +104,9 @@ export const styles: [
 			disabledStyle,
 		],
 	],
-	[
-		"PrimaryButton",
-		[
-			{
-				...baseButtonStyle,
-				background: _color_primaryBackground,
-				textColor: _color_primaryBackground.text(),
-			},
-			{
-				...hoveredNotDisabled,
-				background: _color_primaryBackground.contrast(0.2),
-			},
-			{
-				...pressedNotDisabled,
-				background: _color_primaryBackground.contrast(-0.1),
-			},
-			disabledStyle,
-		],
-	],
+	["PrimaryButton", makeBgButtonStyle(ui.color.PRIMARY_BG)],
+	["DangerButton", makeBgButtonStyle(ui.color.DANGER_BG)],
+	["SuccessButton", makeBgButtonStyle(ui.color.SUCCESS_BG)],
 	[
 		"PlainButton",
 		[
@@ -219,7 +211,7 @@ export const styles: [
 		[
 			{
 				borderColor: _color_text.alpha(0.5),
-				textColor: _color_primaryBackground, // :checked fill
+				textColor: ui.color.PRIMARY_BG, // :checked fill
 				padding: { y: 4 },
 				css: { cursor: "pointer" },
 			},

--- a/packages/frame-web/src/style/defaults/styles.ts
+++ b/packages/frame-web/src/style/defaults/styles.ts
@@ -22,8 +22,6 @@ const baseButtonStyle: CombinedStyleType = {
 	borderRadius: 12,
 	borderThickness: 1,
 	borderColor: _color_clear,
-	background: _color_controlBase,
-	textColor: _color_controlBase.text(),
 	fontWeight: 600,
 	textAlign: "center",
 	lineBreakMode: "ellipsis",
@@ -62,11 +60,20 @@ const pressedNotDisabled: CombinedStyleType = {
 	[UIStyle.STATE_DISABLED]: false,
 };
 
-function makeBgButtonStyle(bg: UIColor) {
+function makeBgButtonStyle(bg: UIColor, baseBg?: UIColor, baseFg?: UIColor) {
+	let fg = bg.text();
 	return [
-		{ ...baseButtonStyle, background: bg, textColor: bg.text() },
-		{ ...hoveredNotDisabled, background: bg.contrast(0.2) },
-		{ ...pressedNotDisabled, background: bg.contrast(-0.1) },
+		{ ...baseButtonStyle, background: baseBg || bg, textColor: baseFg || fg },
+		{
+			...hoveredNotDisabled,
+			background: bg.contrast(-0.1),
+			textColor: fg,
+		},
+		{
+			...pressedNotDisabled,
+			background: bg.contrast(0.1),
+			textColor: fg,
+		},
 		disabledStyle,
 	];
 }
@@ -89,24 +96,13 @@ export const styles: [
 			},
 		],
 	],
-	[
-		"Button",
-		[
-			baseButtonStyle,
-			{
-				...hoveredNotDisabled,
-				background: _color_controlBase.contrast(-0.1),
-			},
-			{
-				...pressedNotDisabled,
-				background: _color_controlBase.contrast(0.1),
-			},
-			disabledStyle,
-		],
-	],
+	["Button", makeBgButtonStyle(_color_controlBase)],
 	["PrimaryButton", makeBgButtonStyle(ui.color.PRIMARY_BG)],
-	["DangerButton", makeBgButtonStyle(ui.color.DANGER_BG)],
 	["SuccessButton", makeBgButtonStyle(ui.color.SUCCESS_BG)],
+	[
+		"DangerButton",
+		makeBgButtonStyle(ui.color.DANGER_BG, _color_controlBase, ui.color.DANGER),
+	],
 	[
 		"PlainButton",
 		[

--- a/packages/frame-web/test/esbuild-es2015/src/count/CountActivity.tsx
+++ b/packages/frame-web/test/esbuild-es2015/src/count/CountActivity.tsx
@@ -3,7 +3,7 @@ import {
 	app,
 } from "../../../../lib/desk-framework-web.es2015.esm.min";
 import body from "./body";
-import messages from "./messages";
+import text from "../text";
 
 export class CountActivity extends Activity {
 	count = 0;
@@ -14,7 +14,7 @@ export class CountActivity extends Activity {
 
 	onCountDown() {
 		if (this.count > 0) this.count--;
-		else app.showAlertDialogAsync(messages.negativeError);
+		else app.showAlertDialogAsync(text.negativeError);
 	}
 
 	onCountUp() {

--- a/packages/frame-web/test/esbuild-es2015/src/count/messages.tsx
+++ b/packages/frame-web/test/esbuild-es2015/src/count/messages.tsx
@@ -1,8 +1,0 @@
-import { MessageDialogOptions } from "../../../../lib/desk-framework-web.es2015.esm.min";
-
-export default {
-	negativeError: new MessageDialogOptions(
-		["Can’t count down further", "This counter doesn’t go below zero."],
-		"OK",
-	),
-};

--- a/packages/frame-web/test/esbuild-es2015/src/main/MainActivity.tsx
+++ b/packages/frame-web/test/esbuild-es2015/src/main/MainActivity.tsx
@@ -4,8 +4,10 @@ import {
 	ViewEvent,
 	Activity,
 	ui,
+	WebTheme,
 } from "../../../../lib/desk-framework-web.es2015.esm.min";
 import { CountActivity } from "../count/CountActivity";
+import text from "../text";
 import body from "./body";
 
 export class MainActivity extends Activity {
@@ -35,5 +37,12 @@ export class MainActivity extends Activity {
 			"Primary",
 			this.selectedTheme === "dark" ? ui.color.GREEN : ui.color.BLUE,
 		);
+	}
+
+	async onZoomMenu(e: ViewEvent<UIButton>) {
+		let size = await app.showModalMenuAsync(text.zoomMenu, e.source);
+		if (size) {
+			WebTheme.setLogicalPxScale(parseFloat(size));
+		}
 	}
 }

--- a/packages/frame-web/test/esbuild-es2015/src/main/_themeToggle.tsx
+++ b/packages/frame-web/test/esbuild-es2015/src/main/_themeToggle.tsx
@@ -24,22 +24,27 @@ const ToggleButtonStyle = ui.style.BUTTON.extend(
 );
 
 export default (
-	<cell style={{ borderRadius: 16, grow: 0 }}>
-		<row spacing={0}>
-			<button
-				label="Light"
-				value="light"
-				pressed={bound("selectedTheme").matches("light")}
-				style={ToggleButtonStyle}
-				onMouseDown="+SetTheme"
-			/>
-			<button
-				label="Dark"
-				value="dark"
-				pressed={bound("selectedTheme").matches("dark")}
-				style={ToggleButtonStyle}
-				onMouseDown="+SetTheme"
-			/>
-		</row>
-	</cell>
+	<row>
+		<button chevron="down" onClick="ZoomMenu">
+			Zoom
+		</button>
+		<cell style={{ borderRadius: 16, grow: 0 }}>
+			<row spacing={0}>
+				<button
+					label="Light"
+					value="light"
+					pressed={bound("selectedTheme").matches("light")}
+					style={ToggleButtonStyle}
+					onMouseDown="+SetTheme"
+				/>
+				<button
+					label="Dark"
+					value="dark"
+					pressed={bound("selectedTheme").matches("dark")}
+					style={ToggleButtonStyle}
+					onMouseDown="+SetTheme"
+				/>
+			</row>
+		</cell>
+	</row>
 );

--- a/packages/frame-web/test/esbuild-es2015/src/text.tsx
+++ b/packages/frame-web/test/esbuild-es2015/src/text.tsx
@@ -1,0 +1,21 @@
+import {
+	MessageDialogOptions,
+	UITheme,
+	ui,
+} from "../../../lib/desk-framework-web.es2015.esm.min";
+
+export default {
+	negativeError: new MessageDialogOptions(
+		["Can’t count down further", "This counter doesn’t go below zero."],
+		"OK",
+	),
+
+	zoomMenu: new UITheme.MenuOptions(
+		[
+			{ text: "Smaller", key: "0.85", icon: ui.icon.MINUS },
+			{ text: "Normal", key: "1", icon: ui.icon.MORE },
+			{ text: "Larger", key: "1.25", icon: ui.icon.PLUS },
+		],
+		140,
+	),
+};


### PR DESCRIPTION
This adds a 'variant' concept, applied at the `ui` functions level (e.g. `ui.button(...)`, **not** in `UIComponent` itself) as well as in the `ViewComposite` constructor. Variants contain presets that are applied before other specified presets, and are therefore just a shortcut for adding predefined attributes along with styles.

Variants now replace the various style properties on Web app options.

(This PR also adds a `DangerButton` and `SuccessButton` style which use the appropriate theme styles. Button color styles are somewhat hard to extend because of the way hover/active styles work, so this makes it easier to use these common types of buttons).