### PR TITLE
Make UICell a full container type again

### DIFF
--- a/docs/app/src/SearchView.tsx
+++ b/docs/app/src/SearchView.tsx
@@ -82,7 +82,7 @@ export default (
 			</cell>
 			<cell>
 				<scroll position={{ gravity: "cover" }}>
-					<list items={bound.list("results")} maxItems={50} allowKeyboardFocus>
+					<list items={bound.list("results")} maxItems={50}>
 						<cell
 							allowFocus
 							style={ResultCellStyle}
@@ -90,6 +90,7 @@ export default (
 							onEnterKeyPress="GoToResult"
 							onArrowUpKeyPress="FocusPrevious"
 							onArrowDownKeyPress="FocusNext"
+							accessibleRole="listitem"
 						>
 							<column align="start">
 								<row>
@@ -103,6 +104,11 @@ export default (
 								</label>
 							</column>
 						</cell>
+						<cell
+							style={{ grow: 0 }}
+							allowKeyboardFocus
+							accessibleRole="list"
+						/>
 					</list>
 				</scroll>
 			</cell>

--- a/packages/frame-core/src/ui/composites/UIListView.ts
+++ b/packages/frame-core/src/ui/composites/UIListView.ts
@@ -7,7 +7,7 @@ import {
 	Observer,
 } from "../../base/index.js";
 import { ERROR, err } from "../../errors.js";
-import type { UIColumn, UIRow } from "../containers/index.js";
+import type { UIContainer } from "../containers/index.js";
 
 /**
  * A view composite that manages views for each item in a list of objects or values
@@ -96,20 +96,14 @@ export class UIListView<
 		> & {
 			/** List of objects, either an array, {@link ManagedList} object, or binding for either */
 			items?: BindingOrValue<Iterable<any>>;
-			/** True if the _container_ view object may receive input focus using the keyboard (e.g. Tab key) */
-			allowKeyboardFocus?: boolean;
 			/** Event that's emitted when list item views are rendered */
 			onListItemsChange?: string;
 		},
 	) {
 		super.applyViewPreset(preset);
 		if ((preset as any).Body) {
-			let Body = (preset as any).Body as ViewClass<UIColumn | UIRow>;
-			this.createView = () => {
-				let view = new Body();
-				if (preset.allowKeyboardFocus) view.allowKeyboardFocus = true;
-				return view;
-			};
+			let Body = (preset as any).Body as ViewClass<UIContainer>;
+			this.createView = () => new Body();
 			delete (preset as any).Body;
 		}
 		if ((preset as any).Observer) {
@@ -123,7 +117,7 @@ export class UIListView<
 	 * - On instances of preset UIList classes, this property defaults to a column view without any spacing, but can be preset to another container view.
 	 * - This property should not be changed on existing UIList instances.
 	 */
-	declare body: UIRow | UIColumn;
+	declare body: UIContainer;
 
 	/**
 	 * The list of objects, from which each object is used to construct one view object

--- a/packages/frame-core/src/ui/containers/UICell.ts
+++ b/packages/frame-core/src/ui/containers/UICell.ts
@@ -7,7 +7,7 @@ import { UIContainer } from "./UIContainer.js";
 /**
  * A view class that represents a cell container component
  *
- * @description A cell container functions like a regular container component, and lays out other components either vertically (default) or horizontally.
+ * @description A cell container functions like a basic container component (using column layout), taking up as much space as possible by default, and with additional properties for decoration and styling.
  *
  * @online_docs Refer to the Desk website for more documentation on using this UI component class.
  */
@@ -28,6 +28,8 @@ export class UICell extends UIContainer {
 			| "opacity"
 			| "effect"
 			| "style"
+			| "allowFocus"
+			| "allowKeyboardFocus"
 		> & {
 			/** Event that's emitted when the mouse cursor enters the cell area */
 			onMouseEnter?: string;
@@ -35,6 +37,7 @@ export class UICell extends UIContainer {
 			onMouseLeave?: string;
 		},
 	) {
+		if (preset.allowKeyboardFocus) preset.allowFocus = true;
 		super.applyViewPreset(preset);
 	}
 
@@ -61,6 +64,22 @@ export class UICell extends UIContainer {
 
 	/** The style to be applied to this cell */
 	style?: UIStyle.TypeOrOverrides<UICell.StyleType> = undefined;
+
+	/** The spacing property exists on {@link UIRow} and {@link UIColumn} and cannot be used on cells */
+	spacing?: never;
+
+	/**
+	 * True if this cell *itself* may receive direct input focus
+	 * - This property can't be changed after rendering.
+	 */
+	allowFocus?: boolean;
+
+	/**
+	 * True if this cell *itself* may receive input focus using the keyboard (e.g. Tab key)
+	 * - This property can't be changed after rendering.
+	 * - If this property is set to true, allowFocus is assumed to be true as well and no longer checked.
+	 */
+	allowKeyboardFocus?: boolean;
 }
 
 export namespace UICell {

--- a/packages/frame-core/src/ui/containers/UIColumn.ts
+++ b/packages/frame-core/src/ui/containers/UIColumn.ts
@@ -9,11 +9,6 @@ import { UIContainer } from "./UIContainer.js";
  * @online_docs Refer to the Desk website for more documentation on using this UI component class.
  */
 export class UIColumn extends UIContainer {
-	/** Creates a new column container view object with the provided view content */
-	constructor(...content: View[]) {
-		super(...content);
-	}
-
 	/**
 	 * Applies the provided preset properties to this object
 	 * - This method is called automatically. Do not call this method after constructing a UI component.
@@ -22,7 +17,7 @@ export class UIColumn extends UIContainer {
 		preset: View.ViewPreset<
 			UIContainer,
 			this,
-			"width" | "align" | "distribute"
+			"width" | "spacing" | "align" | "distribute"
 		>,
 	) {
 		super.applyViewPreset(preset);
@@ -30,6 +25,13 @@ export class UIColumn extends UIContainer {
 
 	/** Column width, in pixels or CSS length with unit */
 	width?: string | number = undefined;
+
+	/**
+	 * Space between components, in pixels or CSS length with unit
+	 * - This property is undefined by default.
+	 * - If this property is set, its value overrides `separator` from the current {@link UIContainer.layout layout} object (if any).
+	 */
+	spacing?: string | number = undefined;
 
 	/**
 	 * Alignment of content along the horizontal axis

--- a/packages/frame-core/src/ui/containers/UIContainer.ts
+++ b/packages/frame-core/src/ui/containers/UIContainer.ts
@@ -38,15 +38,9 @@ export abstract class UIContainer extends UIComponent {
 		preset: View.ViewPreset<
 			UIComponent,
 			this,
-			| "layout"
-			| "padding"
-			| "spacing"
-			| "allowFocus"
-			| "allowKeyboardFocus"
-			| "asyncContentRendering"
+			"layout" | "padding" | "asyncContentRendering"
 		>,
 	) {
-		if (preset.allowKeyboardFocus) preset.allowFocus = true;
 		super.applyViewPreset(preset);
 	}
 
@@ -76,30 +70,10 @@ export abstract class UIContainer extends UIComponent {
 	padding?: UIComponent.Offsets = undefined;
 
 	/**
-	 * Space between components, in pixels or CSS length with unit
-	 * - This property is only set by default on {@link UIRow}, to apply {@link UITheme.rowSpacing}.
-	 * - If this property is set, its value overrides `separator` from the current {@link layout} object.
-	 */
-	spacing?: string | number = undefined;
-
-	/**
 	 * True if content views should be rendered asynchronously
 	 * - Setting this property to true should result in smoother updates, especially for containers with many content items. However, for containers with fewer, larger items, content view rendering may be delayed by a few milliseconds which may result in visual artifacts.
 	 */
 	asyncContentRendering?: boolean;
-
-	/**
-	 * True if this container *itself* may receive direct input focus
-	 * - This property can't be changed after rendering.
-	 */
-	allowFocus?: boolean;
-
-	/**
-	 * True if this container *itself* may receive input focus using the keyboard (e.g. Tab key)
-	 * - This property can't be changed after rendering.
-	 * - If this property is set to true, allowFocus is assumed to be true as well and no longer checked.
-	 */
-	allowKeyboardFocus?: boolean;
 }
 
 export namespace UIContainer {

--- a/packages/frame-core/src/ui/containers/UIRow.ts
+++ b/packages/frame-core/src/ui/containers/UIRow.ts
@@ -10,24 +10,29 @@ import { UIContainer } from "./UIContainer.js";
  * @online_docs Refer to the Desk website for more documentation on using this UI component class.
  */
 export class UIRow extends UIContainer {
-	/** Creates a new row container view object with the provided view content */
-	constructor(...content: View[]) {
-		super(...content);
-		this.spacing = UITheme.getSpacing();
-	}
-
 	/**
 	 * Applies the provided preset properties to this object
 	 * - This method is called automatically. Do not call this method after constructing a UI component.
 	 */
 	override applyViewPreset(
-		preset: View.ViewPreset<UIContainer, this, "height" | "align" | "gravity">,
+		preset: View.ViewPreset<
+			UIContainer,
+			this,
+			"height" | "spacing" | "align" | "gravity"
+		>,
 	) {
 		super.applyViewPreset(preset);
 	}
 
 	/** Row height, in pixels or CSS length with unit */
 	height?: string | number = undefined;
+
+	/**
+	 * Space between components, in pixels or CSS length with unit
+	 * - This property is set to {@link UITheme.rowSpacing} by default.
+	 * - If this property is set, its value overrides `separator` from the current {@link UIContainer.layout layout} object (if any).
+	 */
+	spacing?: string | number = UITheme.getSpacing();
 
 	/**
 	 * Alignment of content along the horizontal axis

--- a/packages/frame-core/src/ui/controls/UIImage.ts
+++ b/packages/frame-core/src/ui/controls/UIImage.ts
@@ -21,12 +21,8 @@ export class UIImage extends UIComponent {
 		preset: View.ViewPreset<
 			UIComponent,
 			this,
-			"url" | "width" | "height" | "style"
+			"url" | "width" | "height" | "style" | "allowFocus" | "allowKeyboardFocus"
 		> & {
-			/** True if this image may receive input focus */
-			allowFocus?: boolean;
-			/** True if this image may receive input focus using the keyboard (e.g. Tab key) */
-			allowKeyboardFocus?: boolean;
 			/** Event that's emitted when the image couldn't be loaded */
 			onLoadError?: string;
 		},

--- a/packages/frame-core/src/ui/controls/UILabel.ts
+++ b/packages/frame-core/src/ui/controls/UILabel.ts
@@ -40,15 +40,11 @@ export class UILabel extends UIComponent {
 			| "small"
 			| "dim"
 			| "style"
-		> & {
-			/** True if this label may receive input focus */
-			allowFocus?: boolean;
-			/** True if this label may receive input focus using the keyboard; implies `allowFocus` */
-			allowKeyboardFocus?: boolean;
-		},
+			| "allowFocus"
+			| "allowKeyboardFocus"
+		>,
 	) {
 		if (preset.allowKeyboardFocus) preset.allowFocus = true;
-
 		super.applyViewPreset(preset);
 	}
 

--- a/packages/frame-core/src/ui/ui_interface.ts
+++ b/packages/frame-core/src/ui/ui_interface.ts
@@ -12,6 +12,7 @@ import type { UIListView } from "./composites/UIListView.js";
 import type { UIViewRenderer } from "./composites/UIViewRenderer.js";
 import type { UIAnimatedCell, UICell } from "./containers/UICell.js";
 import type { UIColumn } from "./containers/UIColumn.js";
+import type { UIContainer } from "./containers/UIContainer.js";
 import type { UIRow } from "./containers/UIRow.js";
 import type { UIScrollContainer } from "./containers/UIScrollContainer.js";
 import type { UIButton } from "./controls/UIButton.js";
@@ -91,8 +92,11 @@ export interface ui {
 	 * @param content The content that will be added to each instance of the resulting class
 	 * @returns A new class that extends {@link UICell}
 	 */
-	cell(preset: ui.PresetType<UICell>, content?: ViewClass): ViewClass<UICell>;
-	cell(content: ViewClass): ViewClass<UICell>;
+	cell(
+		preset: ui.PresetType<UICell>,
+		...content: ViewClass[]
+	): ViewClass<UICell>;
+	cell(...content: ViewClass[]): ViewClass<UICell>;
 
 	/**
 	 * Creates a preset {@link UIColumn} constructor using the provided options and content
@@ -260,7 +264,7 @@ export interface ui {
 	list(
 		preset: View.ViewPreset<UIListView>,
 		ItemBody: ViewClass,
-		ContainerBody?: ViewClass<UIRow | UIColumn>,
+		ContainerBody?: ViewClass<UIContainer>,
 		BookEnd?: ViewClass,
 	): ViewClass<UIListView>;
 

--- a/packages/frame-core/test/tests/ui/list.ts
+++ b/packages/frame-core/test/tests/ui/list.ts
@@ -239,8 +239,9 @@ describe("UIListView", (scope) => {
 		let Preset = ui.cell(
 			ui.button("button"),
 			ui.list(
-				{ items: new ManagedList(...getObjects()), allowKeyboardFocus: true },
+				{ items: new ManagedList(...getObjects()) },
 				ui.label({ text: bound("item.name"), allowFocus: true }),
+				ui.cell({ allowKeyboardFocus: true, accessibleRole: "list" }),
 			),
 		);
 		app.showPage(new Preset());
@@ -262,7 +263,7 @@ describe("UIListView", (scope) => {
 
 	test("Arrow key focus, single list", async (t) => {
 		let Preset = ui.list(
-			{ items: new ManagedList(...getObjects()), allowKeyboardFocus: true },
+			{ items: new ManagedList(...getObjects()) },
 			ui.label({
 				text: bound("item.name"),
 				allowFocus: true,

--- a/packages/frame-test/src/renderer/UICellRenderer.ts
+++ b/packages/frame-test/src/renderer/UICellRenderer.ts
@@ -1,9 +1,4 @@
-import {
-	ManagedEvent,
-	RenderContext,
-	UICell,
-	ui,
-} from "@desk-framework/frame-core";
+import { ManagedEvent, UICell, ui } from "@desk-framework/frame-core";
 import { TestOutputElement } from "../app/TestOutputElement.js";
 import { getBaseStyleClass } from "./TestBaseObserver.js";
 import { UIContainerRenderer } from "./UIContainerRenderer.js";
@@ -46,12 +41,17 @@ export class UICellRenderer extends UIContainerRenderer<UICell> {
 
 	override getOutput() {
 		if (!this.observed) throw ReferenceError();
-		let elt = new TestOutputElement("cell");
-		let output = new RenderContext.Output(this.observed, elt);
-		elt.output = output;
+		let output = super.getOutput();
 		if (this.observed.allowFocus || this.observed.allowKeyboardFocus)
-			elt.focusable = true;
+			output.element.focusable = true;
 		return output;
+	}
+
+	override updateContent(element: TestOutputElement) {
+		let cell = this.observed;
+		if (!cell) return;
+		super.updateContent(element);
+		if (cell.allowFocus || cell.allowKeyboardFocus) element.focusable = true;
 	}
 
 	override updateStyle(element: TestOutputElement) {

--- a/packages/frame-test/src/renderer/UIContainerRenderer.ts
+++ b/packages/frame-test/src/renderer/UIContainerRenderer.ts
@@ -1,6 +1,7 @@
 import {
 	ManagedEvent,
 	RenderContext,
+	UICell,
 	UIColumn,
 	UIContainer,
 	UIRow,
@@ -57,16 +58,15 @@ export class UIContainerRenderer<
 
 	getOutput() {
 		if (!this.observed) throw ReferenceError();
-		let isRow = this.observed instanceof UIRow;
-		let isColumn = this.observed instanceof UIColumn;
-		let isForm = this.observed.accessibleRole === "form";
-		let elt = new TestOutputElement(
-			isRow ? "row" : isColumn ? "column" : isForm ? "form" : "container",
-		);
+		let type: TestOutputElement.TypeString;
+		if (this.observed.accessibleRole === "form") type = "form";
+		else if (this.observed instanceof UICell) type = "cell";
+		else if (this.observed instanceof UIRow) type = "row";
+		else if (this.observed instanceof UIColumn) type = "column";
+		else type = "container";
+		let elt = new TestOutputElement(type);
 		let output = new RenderContext.Output(this.observed, elt);
 		elt.output = output;
-		if (this.observed.allowFocus || this.observed.allowKeyboardFocus)
-			elt.focusable = true;
 		return output;
 	}
 
@@ -83,6 +83,7 @@ export class UIContainerRenderer<
 	updateContent(element: TestOutputElement) {
 		let container = this.observed;
 		if (!container) return;
+
 		if (!this.contentUpdater) {
 			this.contentUpdater = new ContentUpdater(
 				container,
@@ -93,9 +94,6 @@ export class UIContainerRenderer<
 
 		// NOTE: spacing/separators are ignored here because they can't be tested;
 		this.contentUpdater.update(container.content);
-
-		if (container.allowFocus || container.allowKeyboardFocus)
-			element.focusable = true;
 	}
 
 	contentUpdater?: ContentUpdater;

--- a/packages/frame-web/src/renderer/observers/UICellRenderer.ts
+++ b/packages/frame-web/src/renderer/observers/UICellRenderer.ts
@@ -2,6 +2,8 @@ import {
 	ManagedEvent,
 	UIAnimatedCell,
 	UICell,
+	UIComponent,
+	ViewEvent,
 	ui,
 } from "@desk-framework/frame-core";
 import { getCSSLength } from "../../style/DOMStyle.js";
@@ -46,6 +48,41 @@ export class UICellRenderer extends UIContainerRenderer<UICell> {
 		await super.handlePropertyChange(property, value, event);
 	}
 
+	override getOutput() {
+		let output = super.getOutput();
+		let elt = output.element;
+		let cell = this.observed!;
+
+		// make (keyboard) focusable, if needed
+		if (cell.allowKeyboardFocus) elt.tabIndex = 0;
+		else if (cell.allowFocus) elt.tabIndex = -1;
+
+		// add mouse handlers (events not propagated)
+		elt.addEventListener("mouseenter", (e) => {
+			let event = new ManagedEvent(
+				"MouseEnter",
+				cell,
+				{ event: e },
+				undefined,
+				undefined,
+				true,
+			);
+			if (this.observed === cell) cell.emit(event);
+		});
+		elt.addEventListener("mouseleave", (e) => {
+			let event = new ManagedEvent(
+				"MouseLeave",
+				cell,
+				{ event: e },
+				undefined,
+				undefined,
+				true,
+			);
+			if (this.observed === cell) cell.emit(event);
+		});
+		return output;
+	}
+
 	override updateStyle(element: HTMLElement) {
 		let cell = this.observed;
 		if (!cell) return;
@@ -88,4 +125,44 @@ export class UICellRenderer extends UIContainerRenderer<UICell> {
 		// apply output effect, if any
 		if (cell.effect) cell.effect.applyEffect(element, cell);
 	}
+
+	override updateContent(element: HTMLElement) {
+		let cell = this.observed as UICell;
+		if (!cell) return;
+		super.updateContent(element);
+
+		// reset tabindex if needed
+		if (
+			cell.allowKeyboardFocus &&
+			this.lastFocused &&
+			!cell.content.includes(this.lastFocused)
+		) {
+			if (this.element) this.element.tabIndex = 0;
+			this.lastFocused = undefined;
+		}
+	}
+
+	/** Switch tabindex on focus */
+	onFocusIn(e: ViewEvent<UIComponent>) {
+		if (!this.observed || !this.element) return;
+		if (e.source !== this.observed && this.observed.allowKeyboardFocus) {
+			// temporarily disable keyboard focus on this parent
+			// to prevent shift-tab from selecting this element
+			this.element.tabIndex = -1;
+			this.lastFocused = e.source;
+		}
+	}
+
+	/** Switch tabindex back on blur */
+	onFocusOut(e: ViewEvent) {
+		if (!this.observed || !this.element) return;
+		if (e.source !== this.observed && this.observed.allowKeyboardFocus) {
+			// make this parent focusable again
+			this.element.tabIndex = 0;
+			this.lastFocused = undefined;
+		}
+	}
+
+	/** Last focused component, if this cell is keyboard-focusable */
+	lastFocused?: UIComponent;
 }

--- a/packages/frame-web/src/style/MessageDialog.ts
+++ b/packages/frame-web/src/style/MessageDialog.ts
@@ -191,15 +191,13 @@ export class MessageDialog
 		if (MessageDialog.styles.reverseButtons) buttons.reverse();
 		return new (ui.cell(
 			{ variant: MessageDialog.styles.containerVariant },
-			ui.column(
-				ui.cell(
-					{ variant: MessageDialog.styles.messageCellVariant },
-					ui.column(...messageLabels),
-				),
-				ui.cell(
-					{ variant: MessageDialog.styles.buttonCellVariant },
-					ui.row({ layout: MessageDialog.styles.buttonRowLayout }, ...buttons),
-				),
+			ui.cell(
+				{ variant: MessageDialog.styles.messageCellVariant },
+				ui.column(...messageLabels),
+			),
+			ui.cell(
+				{ variant: MessageDialog.styles.buttonCellVariant },
+				ui.row({ layout: MessageDialog.styles.buttonRowLayout }, ...buttons),
 			),
 		))();
 	}

--- a/packages/frame-web/test/esbuild/src/counter.tsx
+++ b/packages/frame-web/test/esbuild/src/counter.tsx
@@ -2,14 +2,12 @@ import { Activity, app, ui } from "../../../dist";
 
 const ViewBody = (
 	<cell>
-		<column distribute="center">
-			<label style={{ bold: true, fontSize: 36 }}>Count: %[count]</label>
-			<spacer height={32} />
-			<row align="center">
-				<button onClick="CountDown">Down</button>
-				<button onClick="CountUp">Up</button>
-			</row>
-		</column>
+		<label style={{ bold: true, fontSize: 36 }}>Count: %[count]</label>
+		<spacer height={32} />
+		<row align="center">
+			<button onClick="CountDown">Down</button>
+			<button onClick="CountUp">Up</button>
+		</row>
 	</cell>
 );
 

--- a/packages/frame-web/test/esm-js/site/ListActivity.js
+++ b/packages/frame-web/test/esm-js/site/ListActivity.js
@@ -28,7 +28,6 @@ class ListItemView extends ViewComposite.withPreset(
 					{ borderThickness: 1, borderColor: ui.color.CLEAR },
 				),
 			padding: { x: 12, y: 4 },
-			margin: { bottom: 8 },
 			allowKeyboardFocus: true,
 			onFocusIn: "+SelectItem",
 			onArrowDownKeyPress: "+FocusNext",
@@ -72,6 +71,7 @@ const page = ui.cell(
 				text: bound.string("item.text"),
 				selected: bound("selectedItem").equals("item"),
 			}),
+			ui.column({ spacing: 8, accessibleRole: "list" }),
 		),
 	),
 );

--- a/packages/frame-web/test/esm/src/counter.tsx
+++ b/packages/frame-web/test/esm/src/counter.tsx
@@ -2,14 +2,12 @@ import { Activity, app, ui } from "../lib/desk-framework-web.es2018.esm.min.js";
 
 const ViewBody = (
 	<cell>
-		<column distribute="center">
-			<label style={{ bold: true, fontSize: 36 }}>Count: %[count]</label>
-			<spacer height={32} />
-			<row align="center">
-				<button onClick="CountDown">Down</button>
-				<button onClick="CountUp">Up</button>
-			</row>
-		</column>
+		<label style={{ bold: true, fontSize: 36 }}>Count: %[count]</label>
+		<spacer height={32} />
+		<row align="center">
+			<button onClick="CountDown">Down</button>
+			<button onClick="CountUp">Up</button>
+		</row>
 	</cell>
 );
 

--- a/packages/frame-web/test/iife/test-iife.js
+++ b/packages/frame-web/test/iife/test-iife.js
@@ -3,18 +3,15 @@ const { app, ui, bound } = desk;
 
 (function () {
 	const ViewBody = ui.cell(
-		ui.column(
-			{ distribute: "center" },
-			ui.label(bound.strf("Count: %n", "count"), {
-				bold: true,
-				fontSize: 36,
-			}),
-			ui.spacer(0, 32),
-			ui.row(
-				{ align: "center" },
-				ui.button("Down", "CountDown"),
-				ui.button("Up", "CountUp"),
-			),
+		ui.label(bound.strf("Count: %n", "count"), {
+			bold: true,
+			fontSize: 36,
+		}),
+		ui.spacer(0, 32),
+		ui.row(
+			{ align: "center" },
+			ui.button("Down", "CountDown"),
+			ui.button("Up", "CountUp"),
 		),
 	);
 

--- a/packages/frame-web/test/parcel/src/counter.tsx
+++ b/packages/frame-web/test/parcel/src/counter.tsx
@@ -2,14 +2,12 @@ import { Activity, app, ui } from "@desk-framework/frame-core";
 
 const ViewBody = (
 	<cell>
-		<column distribute="center">
-			<label style={{ bold: true, fontSize: 36 }}>Count: %[count]</label>
-			<spacer height={32} />
-			<row align="center">
-				<button onClick="CountDown">Down</button>
-				<button onClick="CountUp">Up</button>
-			</row>
-		</column>
+		<label style={{ bold: true, fontSize: 36 }}>Count: %[count]</label>
+		<spacer height={32} />
+		<row align="center">
+			<button onClick="CountDown">Down</button>
+			<button onClick="CountUp">Up</button>
+		</row>
 	</cell>
 );
 

--- a/packages/frame-web/test/webpack/src/counter.js
+++ b/packages/frame-web/test/webpack/src/counter.js
@@ -1,15 +1,12 @@
 import { Activity, app, bound, ui } from "@desk-framework/frame-core";
 
 const ViewBody = ui.cell(
-	ui.column(
-		{ distribute: "center" },
-		ui.label(bound.strf("Count: %i", "count"), { bold: true, fontSize: 36 }),
-		ui.spacer({ height: 32 }),
-		ui.row(
-			{ align: "center" },
-			ui.button("Down", "CountDown"),
-			ui.button("Up", "CountUp"),
-		),
+	ui.label(bound.strf("Count: %i", "count"), { bold: true, fontSize: 36 }),
+	ui.spacer({ height: 32 }),
+	ui.row(
+		{ align: "center" },
+		ui.button("Down", "CountDown"),
+		ui.button("Up", "CountUp"),
 	),
 );
 


### PR DESCRIPTION
Previously the UICell type was limited (artificially) to a single content component, but that seemed rather strange.

This change removes that limitation, and makes a 'cell' a simple container with additional styling.

Also moved spacing to rows/cols only, and (keyboard) focus to cells only. This works out better for rendering too, removing some code out of the hot path.