### PR TITLE
Remove dynamic render controller from ViewComposite class

### DIFF
--- a/packages/frame-core/src/app/ViewComposite.ts
+++ b/packages/frame-core/src/app/ViewComposite.ts
@@ -160,7 +160,7 @@ export class ViewComposite extends View {
 	 * Renders the current view, if any
 	 * - This method is called automatically whenever required. It's not necessary to invoke this method from an application, or to override it.
 	 */
-	render(callback?: RenderContext.RenderCallback) {
+	render(callback: RenderContext.RenderCallback) {
 		if (!this.body) {
 			let body = this.createView();
 			if (body) {
@@ -178,11 +178,10 @@ export class ViewComposite extends View {
 		if (this.body && ManagedObject.whence(this.body) !== this) {
 			throw err(ERROR.View_NotAttached);
 		}
-		if (callback && !this._renderer.isRendered()) this.beforeRender();
-		this._renderer.render(this.body, callback);
+		if (!this._rendered) this.beforeRender();
+		this.body?.render(callback);
 		return this;
 	}
 
-	/** Stateful renderer wrapper, handles content component */
-	private _renderer = new RenderContext.ViewController();
+	private _rendered = false;
 }

--- a/packages/frame-core/src/ui/composites/UIAnimationView.ts
+++ b/packages/frame-core/src/ui/composites/UIAnimationView.ts
@@ -48,7 +48,7 @@ export class UIAnimationView extends ViewComposite {
 		}
 	}
 
-	override render(callback?: RenderContext.RenderCallback) {
+	override render(callback: RenderContext.RenderCallback) {
 		if (callback) {
 			let orig = callback;
 			let result: RenderContext.RenderCallback = (callback = (

--- a/packages/frame-core/src/ui/composites/UIConditionalView.ts
+++ b/packages/frame-core/src/ui/composites/UIConditionalView.ts
@@ -26,16 +26,16 @@ export class UIConditionalView extends View {
 			},
 			set(this: UIConditionalView, v) {
 				state = !!v;
-				if (!!this._body !== state) {
+				if (!!this.body !== state) {
 					if (state && this._Body) {
-						this._body = this.attach(new this._Body(), (e) => {
+						this.body = this.attach(new this._Body(), (e) => {
 							if (!e.noPropagation) {
 								this.emit(ManagedEvent.withDelegate(e, this));
 							}
 						});
 					} else {
-						this._body?.unlink();
-						this._body = undefined;
+						this.body?.unlink();
+						this.body = undefined;
 					}
 					this.render();
 				}
@@ -64,15 +64,18 @@ export class UIConditionalView extends View {
 	 */
 	declare state: boolean;
 
+	/** The current view content to be rendered */
+	body?: View;
+
 	/** The conditional view body, constructed each time state becomes true */
 	private _Body?: ViewClass;
 
 	render(callback?: RenderContext.RenderCallback) {
 		// skip extra rendering if view didn't actually change
-		if (!callback && this._body === this._renderer?.lastView) return this;
+		if (!callback && this.body === this._renderer?.lastView) return this;
 
 		// use given callback to (re-) render view
-		this._renderer.render(this._body, callback);
+		this._renderer.render(this.body, callback);
 		return this;
 	}
 
@@ -83,21 +86,18 @@ export class UIConditionalView extends View {
 	 * @returns An array with instances of the provided view class; may be empty but never undefined.
 	 */
 	findViewContent<T extends View>(type: ViewClass<T>): T[] {
-		return this._body
-			? this._body instanceof type
-				? [this._body]
-				: this._body.findViewContent(type)
+		return this.body
+			? this.body instanceof type
+				? [this.body]
+				: this.body.findViewContent(type)
 			: [];
 	}
 
 	/** Requests input focus on the current view element */
 	requestFocus() {
-		this._body?.requestFocus();
+		this.body?.requestFocus();
 		return this;
 	}
-
-	/** The current view to be rendered */
-	private _body?: View;
 
 	/** Stateful renderer wrapper, handles content component */
 	private _renderer = new RenderContext.ViewController();

--- a/packages/frame-core/src/ui/composites/UIConditionalView.ts
+++ b/packages/frame-core/src/ui/composites/UIConditionalView.ts
@@ -1,4 +1,10 @@
-import { View, ViewClass, ViewComposite } from "../../app/index.js";
+import {
+	RenderContext,
+	View,
+	ViewClass,
+	ViewComposite,
+} from "../../app/index.js";
+import { ManagedEvent } from "../../base/index.js";
 
 /**
  * A view composite that automatically creates and unlinks the contained view
@@ -7,7 +13,7 @@ import { View, ViewClass, ViewComposite } from "../../app/index.js";
  *
  * @online_docs Refer to the Desk website for more documentation on using this UI component class.
  */
-export class UIConditionalView extends ViewComposite {
+export class UIConditionalView extends View {
 	constructor() {
 		super();
 
@@ -20,14 +26,16 @@ export class UIConditionalView extends ViewComposite {
 			},
 			set(this: UIConditionalView, v) {
 				state = !!v;
-				if (!!this.body !== state) {
+				if (!!this._body !== state) {
 					if (state && this._Body) {
-						this.body = this.attach(new this._Body(), (e) => {
-							this.delegateViewEvent(e);
+						this._body = this.attach(new this._Body(), (e) => {
+							if (!e.noPropagation) {
+								this.emit(ManagedEvent.withDelegate(e, this));
+							}
 						});
 					} else {
-						if (this.body) this.body.unlink();
-						this.body = undefined;
+						this._body?.unlink();
+						this._body = undefined;
 					}
 					this.render();
 				}
@@ -58,4 +66,39 @@ export class UIConditionalView extends ViewComposite {
 
 	/** The conditional view body, constructed each time state becomes true */
 	private _Body?: ViewClass;
+
+	render(callback?: RenderContext.RenderCallback) {
+		// skip extra rendering if view didn't actually change
+		if (!callback && this._body === this._renderer?.lastView) return this;
+
+		// use given callback to (re-) render view
+		this._renderer.render(this._body, callback);
+		return this;
+	}
+
+	/**
+	 * Searches the view hierarchy for view objects of the provided type
+	 * @summary This method looks for matching view objects in the current view structure — including the current view itself. If a component is an instance of the provided class, it's added to the list. Components _within_ matching components aren't searched for further matches.
+	 * @param type A view class
+	 * @returns An array with instances of the provided view class; may be empty but never undefined.
+	 */
+	findViewContent<T extends View>(type: ViewClass<T>): T[] {
+		return this._body
+			? this._body instanceof type
+				? [this._body]
+				: this._body.findViewContent(type)
+			: [];
+	}
+
+	/** Requests input focus on the current view element */
+	requestFocus() {
+		this._body?.requestFocus();
+		return this;
+	}
+
+	/** The current view to be rendered */
+	private _body?: View;
+
+	/** Stateful renderer wrapper, handles content component */
+	private _renderer = new RenderContext.ViewController();
 }

--- a/packages/frame-core/src/ui/composites/UIListView.ts
+++ b/packages/frame-core/src/ui/composites/UIListView.ts
@@ -29,10 +29,6 @@ export class UIListView<
 				bound("items.*").bindTo(this, doUpdate);
 				bound("firstIndex").bindTo(this, doUpdate);
 				bound("maxItems").bindTo(this, doUpdate);
-
-				// create view already to avoid unnecessary async updates
-				list.render();
-				if (!list.body) throw Error();
 				this.doUpdateAsync();
 			}
 			override beforeUnlink() {

--- a/packages/frame-core/src/ui/composites/UIViewRenderer.ts
+++ b/packages/frame-core/src/ui/composites/UIViewRenderer.ts
@@ -77,7 +77,7 @@ export class UIViewRenderer extends View {
 
 	/** Requests input focus on the current view element */
 	requestFocus() {
-		if (this.view) this.view.requestFocus();
+		this.view?.requestFocus();
 		return this;
 	}
 

--- a/packages/frame-core/test/tests/ui/form.ts
+++ b/packages/frame-core/test/tests/ui/form.ts
@@ -172,7 +172,7 @@ describe("UIFormContext", () => {
 		);
 		let view = new MyComp();
 		expect(view).toHaveProperty("formContext");
-		view.render();
+		view.render((() => {}) as any);
 		let row = view.body as UIRow;
 		let [label, tf] = row.content.toArray() as [UILabel, UITextField];
 		view.formContext = ctx;

--- a/packages/frame-core/test/tests/ui/jsx.tsx
+++ b/packages/frame-core/test/tests/ui/jsx.tsx
@@ -20,6 +20,10 @@ import {
 } from "../../../dist/index.js";
 
 describe("JSX", () => {
+	function renderComposite(c: ViewComposite) {
+		c.render((() => {}) as any);
+	}
+
 	test("Single component", () => {
 		let MyCell = <cell />;
 		let cell = new MyCell();
@@ -98,7 +102,7 @@ describe("JSX", () => {
 		const MyView = ViewComposite.define({ foo: "" }, <label>Foo</label>);
 		let ViewPreset = <MyView foo="bar" />;
 		let c = new ViewPreset() as ViewComposite;
-		c.render();
+		renderComposite(c);
 		expect(c).toHaveProperty("foo").toBe("bar");
 		expect(c.findViewContent(UILabel)[0])
 			.toHaveProperty("text")
@@ -114,7 +118,7 @@ describe("JSX", () => {
 		}
 		let ViewPreset = <MyView foo="bar" />;
 		let c = new ViewPreset() as ViewComposite;
-		c.render();
+		renderComposite(c);
 		expect(c).toHaveProperty("foo").toBe("bar");
 		expect(c.findViewContent(UILabel)[0])
 			.toHaveProperty("text")
@@ -135,7 +139,7 @@ describe("JSX", () => {
 		let cell = new MyCell() as UICell;
 		expect(cell.content).asArray().toBeArray(1);
 		expect(cell.content.first()).toHaveProperty("chevron").toBe("down");
-		(cell.content.first() as ViewComposite).render();
+		renderComposite(cell.content.first() as ViewComposite);
 		expect(cell.findViewContent(UIButton)[0])
 			.toHaveProperty("chevron")
 			.toBe("down");
@@ -163,7 +167,7 @@ describe("JSX", () => {
 		expect(viewComposite).toHaveProperty("foo").toBe("bar");
 
 		t.log("Render content of view composite");
-		viewComposite.render();
+		renderComposite(viewComposite);
 		let column = viewComposite.findViewContent(UIColumn)[0];
 		expect(column).toBe(viewComposite.body);
 		expect(column).toHaveProperty("spacing").toBe(8);


### PR DESCRIPTION
ViewComposite views are created synchronously so they don't need a dynamic render controller anymore. This benefits performance.