### PR TITLE
Rework bindings

### DIFF
--- a/docs/app/src/SearchView.tsx
+++ b/docs/app/src/SearchView.tsx
@@ -1,4 +1,4 @@
-import { UIStyle, bound, ui } from "@desk-framework/frame-core";
+import { $activity, $list, UIStyle, ui } from "@desk-framework/frame-core";
 
 const TextFieldStyle = ui.style.TEXTFIELD.extend(
 	{
@@ -76,14 +76,14 @@ export default (
 					</row>
 				</cell>
 				<cell
-					hidden={bound.boolean("!hasInput").or("!loading")}
+					hidden={$activity.bind("hasInput").and("loading").not()}
 					padding={{ y: 32 }}
 				>
 					<label>Loading...</label>
 				</cell>
 				<cell>
 					<scroll position={{ gravity: "cover" }}>
-						<list items={bound.list("results")} maxItems={50}>
+						<list items={$activity.list("results")} maxItems={50}>
 							<cell
 								allowFocus
 								style={ResultCellStyle}
@@ -96,12 +96,12 @@ export default (
 								<column align="start">
 									<row>
 										<label style={{ fontWeight: 500, shrink: 0 }}>
-											{bound.string("item.title")}
+											{$list.string("item.title")}
 										</label>
-										<label dim>{bound.string("item.showId")}</label>
+										<label dim>{$list.string("item.showId")}</label>
 									</row>
 									<label style={{ padding: 0, fontSize: 14 }} htmlFormat>
-										{bound.string("item.abstract")}
+										{$list.string("item.abstract")}
 									</label>
 								</column>
 							</cell>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^20.8.7",
-				"c8": "^8.0.1",
+				"c8": "^9.1.0",
 				"concurrently": "^8.2.1",
 				"esbuild": "^0.19.5",
 				"glob": "^10.3.10",
@@ -539,19 +539,18 @@
 			}
 		},
 		"node_modules/c8": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/c8/-/c8-8.0.1.tgz",
-			"integrity": "sha512-EINpopxZNH1mETuI0DzRA4MZpAUH+IFiRhnmFD3vFr3vdrgxqi3VfE3KL0AIL+zDq8rC9bZqwM/VDmmoe04y7w==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/c8/-/c8-9.1.0.tgz",
+			"integrity": "sha512-mBWcT5iqNir1zIkzSPyI3NCR9EZCVI3WUD+AVO17MVWTSFNyUueXE82qTeampNtTr+ilN/5Ua3j24LgbCKjDVg==",
 			"dev": true,
 			"dependencies": {
 				"@bcoe/v8-coverage": "^0.2.3",
 				"@istanbuljs/schema": "^0.1.3",
 				"find-up": "^5.0.0",
-				"foreground-child": "^2.0.0",
+				"foreground-child": "^3.1.1",
 				"istanbul-lib-coverage": "^3.2.0",
 				"istanbul-lib-report": "^3.0.1",
 				"istanbul-reports": "^3.1.6",
-				"rimraf": "^3.0.2",
 				"test-exclude": "^6.0.0",
 				"v8-to-istanbul": "^9.0.0",
 				"yargs": "^17.7.2",
@@ -561,64 +560,7 @@
 				"c8": "bin/c8.js"
 			},
 			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/c8/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/c8/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"dev": true,
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/c8/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/c8/node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dev": true,
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"node": ">=14.14.0"
 			}
 		},
 		"node_modules/call-bind": {
@@ -940,16 +882,19 @@
 			}
 		},
 		"node_modules/foreground-child": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
-			"integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+			"integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
 			"dev": true,
 			"dependencies": {
 				"cross-spawn": "^7.0.0",
-				"signal-exit": "^3.0.2"
+				"signal-exit": "^4.0.1"
 			},
 			"engines": {
-				"node": ">=8.0.0"
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -1008,34 +953,6 @@
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/glob/node_modules/foreground-child": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-			"integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
-			"dev": true,
-			"dependencies": {
-				"cross-spawn": "^7.0.0",
-				"signal-exit": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/glob/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
-			"engines": {
-				"node": ">=14"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -1714,10 +1631,16 @@
 			}
 		},
 		"node_modules/signal-exit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"dev": true
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
 		},
 		"node_modules/spawn-command": {
 			"version": "0.0.2",
@@ -2464,67 +2387,22 @@
 			}
 		},
 		"c8": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/c8/-/c8-8.0.1.tgz",
-			"integrity": "sha512-EINpopxZNH1mETuI0DzRA4MZpAUH+IFiRhnmFD3vFr3vdrgxqi3VfE3KL0AIL+zDq8rC9bZqwM/VDmmoe04y7w==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/c8/-/c8-9.1.0.tgz",
+			"integrity": "sha512-mBWcT5iqNir1zIkzSPyI3NCR9EZCVI3WUD+AVO17MVWTSFNyUueXE82qTeampNtTr+ilN/5Ua3j24LgbCKjDVg==",
 			"dev": true,
 			"requires": {
 				"@bcoe/v8-coverage": "^0.2.3",
 				"@istanbuljs/schema": "^0.1.3",
 				"find-up": "^5.0.0",
-				"foreground-child": "^2.0.0",
+				"foreground-child": "^3.1.1",
 				"istanbul-lib-coverage": "^3.2.0",
 				"istanbul-lib-report": "^3.0.1",
 				"istanbul-reports": "^3.1.6",
-				"rimraf": "^3.0.2",
 				"test-exclude": "^6.0.0",
 				"v8-to-istanbul": "^9.0.0",
 				"yargs": "^17.7.2",
 				"yargs-parser": "^21.1.1"
-			},
-			"dependencies": {
-				"brace-expansion": {
-					"version": "1.1.11",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-					"dev": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"glob": {
-					"version": "7.2.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-					"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.1.1",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"minimatch": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-					"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-					"dev": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
 			}
 		},
 		"call-bind": {
@@ -2764,13 +2642,13 @@
 			"dev": true
 		},
 		"foreground-child": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
-			"integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+			"integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
 			"dev": true,
 			"requires": {
 				"cross-spawn": "^7.0.0",
-				"signal-exit": "^3.0.2"
+				"signal-exit": "^4.0.1"
 			}
 		},
 		"fs.realpath": {
@@ -2814,24 +2692,6 @@
 				"minimatch": "^9.0.1",
 				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
 				"path-scurry": "^1.10.1"
-			},
-			"dependencies": {
-				"foreground-child": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-					"integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^7.0.0",
-						"signal-exit": "^4.0.1"
-					}
-				},
-				"signal-exit": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-					"dev": true
-				}
 			}
 		},
 		"has": {
@@ -3307,9 +3167,9 @@
 			}
 		},
 		"signal-exit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
 			"dev": true
 		},
 		"spawn-command": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"test": "npm run test:test && npm run test:core",
 		"test:core": "cd packages/frame-core && npm test",
 		"test:test": "cd packages/frame-test && npm test",
+		"c8": "c8 -r html npm run test",
 		"check-format": " concurrently  npm:check-format:*",
 		"check-format:other": "prettier --check \"**/*.md\" \"**/{package,tsconfig,config,launch,tasks}.json\"",
 		"check-format:core": "cd packages/frame-core && npm run check-format",
@@ -37,7 +38,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^20.8.7",
-		"c8": "^8.0.1",
+		"c8": "^9.1.0",
 		"concurrently": "^8.2.1",
 		"esbuild": "^0.19.5",
 		"glob": "^10.3.10",

--- a/packages/frame-core/src/app/NavigationContext.ts
+++ b/packages/frame-core/src/app/NavigationContext.ts
@@ -5,6 +5,7 @@ import type { NavigationTarget } from "./NavigationTarget.js";
 
 /**
  * An object that encapsulates the current location within the application navigation stack, part of the global application context
+ * - An instance of this class is available as {@link GlobalContext.navigation app.navigation}.
  * - This object contains the current location, represented as page ID and detail strings. In a URL-like path, the page ID is the first segment, and the detail is the remainder of the path.
  * - When overridden by a platform-specific (or test) implementation, this object also provides a way to navigate to a new location.
  * @hideconstructor

--- a/packages/frame-core/src/app/RenderContext.ts
+++ b/packages/frame-core/src/app/RenderContext.ts
@@ -1,6 +1,6 @@
 import { ManagedObject } from "../base/index.js";
 import { invalidArgErr, safeCall } from "../errors.js";
-import { app } from "./GlobalContext.js";
+import { app } from "./app.js";
 import { View } from "./View.js";
 
 /**

--- a/packages/frame-core/src/app/ServiceContext.ts
+++ b/packages/frame-core/src/app/ServiceContext.ts
@@ -1,19 +1,19 @@
-import { ManagedEvent } from "../base/ManagedEvent.js";
 import { ManagedList } from "../base/ManagedList.js";
 import { ManagedObject } from "../base/ManagedObject.js";
-import { invalidArgErr, safeCall } from "../errors.js";
+import { $_get } from "../base/object_util.js";
+import { invalidArgErr } from "../errors.js";
 import { Service } from "./Service.js";
 
 /**
- * A container of named services, part of the global application context
+ * A container of service instances, part of the global application context
  *
  * @description
- * This class is a container for named services, which should be accessible by the rest of the application. Services can be set, unset, and replaced using the global service context.
+ * This class is a container for services, each with a unique ID, which should be accessible by the rest of the application. Services can be set, unset, and replaced using the global service context.
  *
  * - Use the {@link add()} method to add or update a service by ID. The service must be an instance of {@link Service} with a valid `id` property. The service is automatically attached to the ServiceContext instance. An alias of this method is available as {@link GlobalContext.addService app.addService()}.
  * - Use the {@link get()} method to retrieve a service by ID, if one is currently registered.
  * - Unlink a service to remove (unregister) it.
- * - Use the {@link observe()} method to observe a particular service by ID and handle events.
+ * - Whenever services are added, removed, or replaced, this object emits a change event.
  *
  * @hideconstructor
  */
@@ -34,6 +34,11 @@ export class ServiceContext extends ManagedObject {
 		return this._list.toArray();
 	}
 
+	/** @internal Property getter for bindings */
+	[$_get](propertyName: string) {
+		return this.get(propertyName);
+	}
+
 	/**
 	 * Adds the specified service
 	 * - If a service with the same ID is currently registered, it will be unlinked and replaced with the new service
@@ -51,37 +56,6 @@ export class ServiceContext extends ManagedObject {
 		return this;
 	}
 
-	/**
-	 * Observes a single service by ID
-	 * @summary This method can be used to observe a particular service for changes and events. The provided handler function is called for every (new) service object, as well as for every event emitted by the service.
-	 * @note This method adds a listener to the service context and/or current service. To avoid memory leaks, you can unlink the returned observer object when it's no longer needed. Alternatively, you can attach the object to a parent object (e.g. an {@link Activity}), which will automatically unlink it when the parent is unlinked.
-	 * @param id The ID of the service to observe
-	 * @param handler A function that's called whenever the service changes or emits an event, or immediately if a service was already registered
-	 * @returns An observer object that includes a reference to the current service; when the object is unlinked, the observer stops listening
-	 *
-	 * @example
-	 * class MyActivity extends Activity {
-	 *   foo = this.attach(
-	 *     app.services.observe<MyService>("Test.MyService", (service, event) => {
-	 *       // handle service changes or events
-	 *       // (also called if service was already registered)
-	 *     })
-	 *   );
-	 *
-	 *   // ... elsewhere
-	 *   doSomething() {
-	 *     let fooService = this.foo.service;
-	 *     // use fooService if it's available...
-	 *   }
-	 * }
-	 */
-	observe<TService extends Service>(
-		id: string,
-		handler?: (service?: TService, event?: ManagedEvent) => void,
-	) {
-		return new ServiceContext.Observer<TService>(this, id, handler);
-	}
-
 	// keep track of services in a list, and forward events
 	private _map?: Map<string, Service>;
 	private _list = this.attach(new ManagedList<Service>(), (e) => {
@@ -91,77 +65,4 @@ export class ServiceContext extends ManagedObject {
 			this.emitChange();
 		}
 	});
-}
-
-export namespace ServiceContext {
-	/**
-	 * An observer for a single service, by ID
-	 * - This class is used to observe a single service by ID. An instance is created by {@link ServiceContext.observe()}.
-	 * - The observer includes a reference to the current service, which is updated automatically. Additionally, the observer is associated with a handler function that's called whenever the service changes or emits an event.
-	 * @see {@link ServiceContext.observe}
-	 */
-	export class Observer<TService extends Service> extends ManagedObject {
-		/**
-		 * Creates a new service observer, do not use directly
-		 * - Use {@link ServiceContext.observe()} to create a new observer
-		 * @see {@link ServiceContext.observe}
-		 */
-		constructor(
-			context: ServiceContext,
-			id: string,
-			handler?: (service?: TService, event?: ManagedEvent) => void,
-		) {
-			super();
-
-			// keep track of current service and listen for events
-			let serviceStop: (() => void) | undefined;
-			const contextChange = () => {
-				let newService = context.get(id) as TService | undefined;
-				if (newService !== this.service) {
-					serviceStop?.();
-					this.service = newService;
-
-					// listen for events on new service
-					newService?.listen({
-						init(_, stop) {
-							serviceStop = stop;
-						},
-						handler,
-					});
-
-					// invoke handler with new service
-					handler?.(newService);
-				}
-			};
-
-			// watch the service context for changes
-			let ctxStop: () => void;
-			context.listen({
-				init(_, stop) {
-					ctxStop = stop;
-				},
-				handler(list, event) {
-					if (event.source === list) contextChange();
-				},
-			});
-
-			// watch the observer itself to stop when unlinked
-			this.listen({
-				unlinked: () => {
-					ctxStop();
-					serviceStop?.();
-					this.service = undefined;
-				},
-			});
-
-			// initialize in case service is already registered
-			safeCall(contextChange);
-		}
-
-		/**
-		 * The currently observed service
-		 * - This property is updated automatically when the service is added, removed, or replaced
-		 */
-		service?: TService = undefined;
-	}
 }

--- a/packages/frame-core/src/app/View.ts
+++ b/packages/frame-core/src/app/View.ts
@@ -63,7 +63,7 @@ export abstract class View extends ManagedObject {
 	 *
 	 * **Property values** — These are set directly on the view object. Each property is set to the corresponding value. However, property names starting with an underscore are ignored. Undefined preset property values are also ignored, except if the property was never set before on the target view (i.e. initializing a new undefined property).
 	 *
-	 * **Bindings** — These are applied on properties the view object. Each property may be bound using an instance of the {@link Binding} class (i.e. the result of {@link bound()} functions), creating the target property and taking effect immediately.
+	 * **Bindings** — These are applied on properties the view object. Each property may be bound using an instance of the {@link Binding} class (i.e. the result of {@link bind()}), creating the target property and taking effect immediately.
 	 *
 	 * **Events** — Events can be handled in two ways, depending on the value of the `on...` property:
 	 * - `onClick: "RemoveItem"` — this intercepts `Click` events and emits `RemoveItem` events instead. The {@link ManagedEvent.inner} property is set to the original `Click` event.

--- a/packages/frame-core/src/app/ViewComposite.ts
+++ b/packages/frame-core/src/app/ViewComposite.ts
@@ -1,7 +1,19 @@
-import { BindingOrValue, ManagedEvent, ManagedObject } from "../base/index.js";
+import {
+	Binding,
+	BindingOrValue,
+	ManagedEvent,
+	ManagedObject,
+	bind,
+} from "../base/index.js";
 import { ERROR, err, errorHandler } from "../errors.js";
 import { RenderContext } from "./RenderContext.js";
 import { View, ViewClass } from "./View.js";
+
+/** Label property used to filter bindings using $view */
+const $_bind_label = Symbol("view");
+
+/** An object that can be used to create bindings for properties of the containing {@link ViewComposite} object */
+export const $view: Binding.Source = bind.$on($_bind_label);
 
 /**
  * A class that encapsulates a dynamic view
@@ -79,6 +91,9 @@ export class ViewComposite extends View {
 	 * - Alternatively, you can set it yourself, e.g. in the constructor. In this case, ensure that the object is a {@link View} instance that's attached directly to this view composite, and events are delegated using {@link ViewComposite.delegateViewEvent}.
 	 */
 	body?: View;
+
+	/** @internal */
+	[$_bind_label] = true;
 
 	/**
 	 * Creates a preset view structure for this view composite, to be overridden

--- a/packages/frame-core/src/app/ViewportContext.ts
+++ b/packages/frame-core/src/app/ViewportContext.ts
@@ -6,6 +6,8 @@ import { ManagedObject } from "../base/index.js";
  * @description
  * A ViewportContext object is available on the global application context, as {@link GlobalContext.viewport app.viewport}. This instance can be used to customize the UI for different viewport sizes — either directly or through a binding.
  *
+ * Bindings for viewport context properties can also be created using the {@link $viewport} object.
+ *
  * @online_docs Refer to the Desk website for more information on responsive design and the viewport context.
  *
  * @example
@@ -16,7 +18,7 @@ import { ManagedObject } from "../base/index.js";
  *
  * @example
  * // Bind to viewport properties from a JSX view:
- * <conditional state={bound("viewport.col3")}>
+ * <conditional state={$viewport.bind("col3")}>
  *   // ...view for wide viewports with at least 3 grid 'columns'
  * </conditional>
  */

--- a/packages/frame-core/src/app/app.ts
+++ b/packages/frame-core/src/app/app.ts
@@ -1,0 +1,15 @@
+import { setErrorHandler } from "../errors.js";
+import { GlobalContext } from "./GlobalContext.js";
+
+/**
+ * The current instance of the global application context
+ *
+ * @description
+ * Use `app` to access properties and methods of {@link GlobalContext}, e.g. `app.theme` and `app.addActivity(...)`. This instance is available immediately when the application starts, and remains the same throughout its lifetime.
+ */
+export const app = new GlobalContext();
+
+// use default error handler
+setErrorHandler((err) => {
+	app.log.error(err);
+});

--- a/packages/frame-core/src/app/app_binding.ts
+++ b/packages/frame-core/src/app/app_binding.ts
@@ -1,0 +1,22 @@
+import { Binding, ManagedObject, bind } from "../base/index.js";
+import type { ViewportContext } from "./ViewportContext.js";
+import type { NavigationContext } from "./NavigationContext.js";
+
+/** @internal Label property used to filter bindings using $app */
+export const $_app_bind_label = Symbol("app");
+
+/**
+ * An object that can be used to create bindings for properties of the {@link ViewportContext} object
+ * - This object can be used to create bindings to control responsive UIs, e.g. to show or hide particular views based on the size of the user's screen or window.
+ */
+export const $viewport: Binding.Source<
+	ManagedObject.PropertiesOf<ViewportContext>
+> = bind.$on($_app_bind_label, "viewport");
+
+/** An object that can be used to create bindings for properties of the {@link NavigationContext} object */
+export const $navigation: Binding.Source<
+	ManagedObject.PropertiesOf<NavigationContext>
+> = bind.$on($_app_bind_label, "navigation");
+
+/** An object that can be used to create bindings for (properties of) services */
+export const $services: Binding.Source = bind.$on($_app_bind_label, "services");

--- a/packages/frame-core/src/app/index.ts
+++ b/packages/frame-core/src/app/index.ts
@@ -14,3 +14,5 @@ export * from "./ViewComposite.js";
 export * from "./LogWriter.js";
 export * from "./MessageDialogOptions.js";
 export * from "./GlobalContext.js";
+export * from "./app_binding.js";
+export * from "./app.js";

--- a/packages/frame-core/src/base/LazyString.ts
+++ b/packages/frame-core/src/base/LazyString.ts
@@ -122,7 +122,7 @@ export function strf(
  * This class is primarily used for string formatting and localization, usually as the result of a call to {@link strf} or to process string-formatted bindings.
  *
  * @see {@link strf}
- * @see {@link bound.strf}
+ * @see {@link bind.strf}
  */
 export class LazyString extends String {
 	/**
@@ -157,7 +157,7 @@ export class LazyString extends String {
 
 	/**
 	 * Creates a new lazily evaluated string instance
-	 * - This method is used by {@link strf()}, {@link bound.strf()}, and other methods. Typically, you don't need to call this constructor yourself.
+	 * - This method is used by {@link strf()}, {@link bind.strf()}, and other methods. Typically, you don't need to call this constructor yourself.
 	 * @param get A function that returns the embedded string value
 	 */
 	constructor(get?: () => string) {
@@ -218,7 +218,7 @@ export class LazyString extends String {
 	/**
 	 * Replaces placeholders in the string with string-formatted values
 	 *
-	 * @summary This method provides the core functionality for {@link strf()} and {@link bound.strf()}. It inserts the provided list of values (or properties of a single object) into the format string, formatted in a specific way, as determined by the placeholder.
+	 * @summary This method provides the core functionality for {@link strf()} and {@link bind.strf()}. It inserts the provided list of values (or properties of a single object) into the format string, formatted in a specific way, as determined by the placeholder.
 	 *
 	 * Placeholders are compatible with C-style _sprintf_, e.g. %s, %+8i, %.5f, etc., as well as the following custom placeholders:
 	 *

--- a/packages/frame-core/src/ui/UIFormContext.ts
+++ b/packages/frame-core/src/ui/UIFormContext.ts
@@ -1,4 +1,4 @@
-import { bound, ManagedObject, StringConvertible } from "../base/index.js";
+import { bind, ManagedObject, StringConvertible } from "../base/index.js";
 import { AppException } from "../app/index.js";
 import { UIComponent } from "./UIComponent.js";
 
@@ -25,8 +25,8 @@ const REQUIRED_ERROR = AppException.type(
  *   ui.textField({ formField: "foo" }),
  *   ui.label({
  *     style: myStyles.errorLabel,
- *     hidden: bound.not("formContext.errors.foo"),
- *     text: bound.string("formContext.errors.foo.message")
+ *     hidden: $activity.not("formContext.errors.foo"),
+ *     text: $activity.string("formContext.errors.foo.message")
  *   }),
  *   ui.button("Go", "Submit")
  * );
@@ -346,5 +346,5 @@ export namespace UIFormContext {
 		});
 	}
 
-	const _boundFormContext = bound("formContext.*");
+	const _boundFormContext = bind("formContext.*");
 }

--- a/packages/frame-core/src/ui/composites/UIListView.ts
+++ b/packages/frame-core/src/ui/composites/UIListView.ts
@@ -1,13 +1,25 @@
 import { View, ViewClass, ViewComposite } from "../../app/index.js";
 import {
+	Binding,
 	BindingOrValue,
 	ManagedEvent,
 	ManagedList,
 	ManagedObject,
-	bound,
+	bind,
 } from "../../base/index.js";
 import { ERROR, err } from "../../errors.js";
 import { UIContainer } from "../containers/index.js";
+
+/** Label property used to filter bindings using $list */
+const $_list_bind_label = Symbol("list");
+
+/**
+ * An object that can be used to create bindings for properties of the containing {@link UIListView.ItemControllerView} object
+ * - The source object includes the `item` property that refers to the list item object, i.e. an element of the list passed to {@link UIListView}.
+ * - Within a list item view, you can bind to properties of the list item object using e.g. `$list.string("item.name")`.
+ */
+export const $list: Binding.Source<`item.${string}` | "item"> =
+	bind.$on($_list_bind_label);
 
 /**
  * A view composite that manages views for each item in a list of objects or values
@@ -26,9 +38,9 @@ export class UIListView<
 			constructor(public list: UIListView) {
 				super();
 				let doUpdate = this.doUpdateAsync.bind(this);
-				bound("items.*").bindTo(this, doUpdate);
-				bound("firstIndex").bindTo(this, doUpdate);
-				bound("maxItems").bindTo(this, doUpdate);
+				bind("items.*").bindTo(this, doUpdate);
+				bind("firstIndex").bindTo(this, doUpdate);
+				bind("maxItems").bindTo(this, doUpdate);
 				this.doUpdateAsync();
 			}
 			override beforeUnlink() {
@@ -324,6 +336,9 @@ export namespace UIListView {
 			this.item = item instanceof ItemValueWrapper ? item.value : item;
 			this._ItemBody = ItemBody;
 		}
+
+		/** @internal */
+		[$_list_bind_label] = true;
 
 		/** The encapsulated list (or array) item */
 		readonly item: TItem;

--- a/packages/frame-core/src/ui/jsx.ts
+++ b/packages/frame-core/src/ui/jsx.ts
@@ -34,7 +34,7 @@ export function jsx(tag: any, presets: any, ...rest: any[]): ViewClass {
 	let fmt = "";
 	let nBindings = 0;
 	let hasText: boolean | undefined;
-	let bindings: any = {};
+	let bindings: { [id: string]: Binding } = {};
 	let components: any[] = [];
 	for (let r of rest) {
 		if (r instanceof LazyString) {
@@ -45,7 +45,7 @@ export function jsx(tag: any, presets: any, ...rest: any[]): ViewClass {
 				/\%\[([^\]\:\s\=]+)(?:\=([^\]\:\s]*))?/g,
 				(s, id, path) => {
 					if (!bindings[id]) {
-						bindings[id] = path || id;
+						bindings[id] = new Binding(path || id);
 						nBindings++;
 					}
 					return "%[" + id;

--- a/packages/frame-core/src/ui/ui_interface.ts
+++ b/packages/frame-core/src/ui/ui_interface.ts
@@ -119,12 +119,12 @@ export interface ui {
 	 *
 	 * @note To enable JSX support for TypeScript projects, set the `jsxFactory` configuration to `ui.jsx`, and import `ui` in each `.tsx` file to allow the compiler to access it.
 	 *
-	 * **Bindings in label text** — Several JSX elements accept text content, namely `<label>`, `<button>`, `<toggle>`, and `<textfield>` (for placeholder text). This text is assigned to the `text`, `label`, or `placeholder` properties, and may consist of plain text and bindings (i.e. the result of {@link bound()} functions, refer to {@link Binding} for more information).
+	 * **Bindings in label text** — Several JSX elements accept text content, namely `<label>`, `<button>`, `<toggle>`, and `<textfield>` (for placeholder text). This text is assigned to the `text`, `label`, or `placeholder` properties, and may consist of plain text and bindings (i.e. the result of {@link bind()}, refer to {@link Binding} for more information).
 	 *
-	 * As a shortcut within JSX text content, bindings may also be specified directly using `%[...]` syntax, which are used with {@link bound.strf()}. In addition, this syntax may be used with aliases and default string values:
+	 * As a shortcut within JSX text content, bindings may also be specified directly using `%[...]` syntax, which are used with {@link bind.strf()}. In addition, this syntax may be used with aliases and default string values:
 	 *
 	 * - `Foo: %[foo]` — inserts a binding for `foo`
-	 * - `Foo: %[foo:.2f]` — inserts a binding for `foo`, and uses {@link bound.strf()} to format the bound value as a number with 2 decimals
+	 * - `Foo: %[foo:.2f]` — inserts a binding for `foo`, and uses {@link bind.strf()} to format the bound value as a number with 2 decimals
 	 * - `Foo: %[foo=somePropertyName]` — inserts a binding for `somePropertyName`, but allows for localization of `Foo: %[foo]` instead
 	 * - `Foo: %[foo=another.propertyName:.2f]` — inserts a bindings for `another.propertyName`, but allows for localization of `Foo: %[foo:.2f]` instead.
 	 * - `Foo: %[foo=some.numProp:?||None]` — inserts a binding for `some.numProp`, but allows for localization of `Foo: %[foo:?||None]` instead (and inserts `None` if the value for `some.numProp` is undefined or an empty string).

--- a/packages/frame-core/test/tests/app/activation.ts
+++ b/packages/frame-core/test/tests/app/activation.ts
@@ -64,6 +64,7 @@ describe("NavigationContext and ActivityContext", () => {
 			app.addActivity(activity);
 			await t.sleep(1);
 			expect(activity.isActive()).toBeTruthy();
+			expect(app.navigation.matchedPageId).toBe("foo");
 		});
 
 		test("Activity activated when app path changed (async)", async (t) => {

--- a/packages/frame-core/test/tests/app/i18n.ts
+++ b/packages/frame-core/test/tests/app/i18n.ts
@@ -1,6 +1,6 @@
 import {
 	app,
-	bound,
+	bind,
 	I18nProvider,
 	LazyString,
 	ManagedObject,
@@ -178,7 +178,7 @@ describe("I18n", (scope) => {
 		let parent: any = new ManagedObject();
 		parent.value = 123;
 		parent.child = parent.attach(new ManagedObject());
-		bound("value").local("test", "format").bindTo(parent.child, "value");
+		bind("value").local("test", "format").bindTo(parent.child, "value");
 		expect(parent.child).toHaveProperty("value").toBe("{123:test,format}");
 	});
 });

--- a/packages/frame-core/test/tests/app/services.ts
+++ b/packages/frame-core/test/tests/app/services.ts
@@ -3,7 +3,8 @@ import {
 	Service,
 	ManagedObject,
 	ServiceContext,
-	Activity,
+	$services,
+	binding,
 } from "../../../dist/index.js";
 import { describe, expect, test } from "@desk-framework/frame-test";
 
@@ -14,8 +15,16 @@ describe("ManagedService", (scope) => {
 	});
 
 	class MyService extends Service {
-		id = "Test.MyService";
+		id = "Test:MyService";
 		foo = 1;
+	}
+
+	class OtherService extends Service {
+		id = "Test.OtherService";
+		bar = 2;
+
+		@binding($services.bind("Test:MyService"))
+		myService?: MyService;
 	}
 
 	test("Service context reference", () => {
@@ -31,12 +40,12 @@ describe("ManagedService", (scope) => {
 		expect(svc.isServiceRegistered()).toBe(false);
 		app.addService(svc);
 		expect(svc.isServiceRegistered()).toBe(true);
-		expect(app.services.get("Test.MyService")).toBe(svc);
-		expect(app.services.get("teST.mYSERvicE")).toBeUndefined();
+		expect(app.services.get("Test:MyService")).toBe(svc);
+		expect(app.services.get("tEst:mYSErViCE")).toBeUndefined();
 		expect([...app.services.getAll()]).toBeArray([svc]);
 
 		svc.unlink();
-		expect(app.services.get("Test.MyService")).toBeUndefined();
+		expect(app.services.get("Test:MyService")).toBeUndefined();
 		expect(svc.isServiceRegistered()).toBe(false);
 	});
 
@@ -48,113 +57,40 @@ describe("ManagedService", (scope) => {
 		expect([...app.services.getAll()]).toBeArray([svc1]);
 		let svc2 = new MyService();
 		app.services.add(svc2);
-		expect(app.services.get("Test.MyService")).toBe(svc2);
+		expect(app.services.get("Test:MyService")).toBe(svc2);
 		expect(svc1.isServiceRegistered()).toBe(false);
 		expect(svc2.isServiceRegistered()).toBe(true);
 		svc2.unlink();
 		expect([...app.services.getAll()]).toBeArray(0);
 	});
 
-	test("Observe single service, after adding", () => {
-		let svc = new MyService();
-		app.services.add(svc);
-		let observer = app.services.observe<MyService>("Test.MyService");
-		expect(observer).toHaveProperty("service").toBe(svc);
-		observer.unlink();
-		expect(observer).toHaveProperty("service").toBeUndefined();
-		app.services.clear();
-	});
-
-	test("Observe single service, before adding", () => {
-		let svc = new MyService();
-		let observer = app.services.observe<MyService>("Test.MyService");
-		expect(observer).toHaveProperty("service").toBeUndefined();
-		app.services.add(svc);
-		expect(observer).toHaveProperty("service").toBe(svc);
-		svc.unlink();
-		expect(observer).toHaveProperty("service").toBeUndefined();
-		observer.unlink();
-	});
-
-	test("Observe service change", () => {
+	test("Bind service", () => {
 		let svc1 = new MyService();
-		let svc2 = new MyService();
 		app.services.add(svc1);
-		let observer = app.services.observe<MyService>("Test.MyService");
-		expect(observer).toHaveProperty("service").toBe(svc1);
-		app.services.add(svc2);
-		expect(observer).toHaveProperty("service").toBe(svc2);
-		observer.unlink();
-		app.services.clear();
+		let other = new OtherService();
+		app.services.add(other);
+		expect(other.myService).toBe(svc1);
+		svc1.unlink();
+		other.unlink();
 	});
 
-	test("Listen for service events, after adding", (t) => {
-		let svc = new MyService();
-		app.services.add(svc); // + service
-		let observer = app.services.observe<MyService>(
-			"Test.MyService",
-			(service, event) => {
-				if (service && service !== svc) t.fail("Service mismatch");
-				if (service) t.count("service");
-				else t.count("unlinked");
-				if (event) t.count(event.name);
-			},
-		);
-		svc.emit("Foo"); // + service, + Foo
-		svc.unlink(); // + unlinked
-		observer.unlink();
-		t.expectCount("service").toBe(2);
-		t.expectCount("unlinked").toBe(1);
-		t.expectCount("Foo").toBe(1);
-	});
-
-	test("Listen for service events, before adding, then change", (t) => {
+	test("Bind service with event listener", (t) => {
 		let svc1 = new MyService();
-		let svc2 = new MyService();
-		let observer = app.services.observe<MyService>(
-			"Test.MyService",
-			(service, event) => {
-				if (service === svc1) t.count("svc1");
-				else if (service === svc2) t.count("svc2");
-				else if (!service) t.count("unlinked");
-				if (event) t.count(event.name);
-			},
-		);
-		app.services.add(svc1); // + svc1
-		svc1.emit("Foo"); // + svc1, + Foo
-		app.services.add(svc2); // + svc2
-		svc2.emit("Bar"); // + svc2, + Bar
-		svc2.unlink(); // + unlinked
-		observer.unlink();
-		t.expectCount("svc1").toBe(2);
-		t.expectCount("svc2").toBe(2);
-		t.expectCount("unlinked").toBe(1);
-		t.expectCount("Foo").toBe(1);
-		t.expectCount("Bar").toBe(1);
-	});
-
-	test("Observe service from activity", (t) => {
-		let svc = new MyService();
-		app.services.add(svc); // + service
-		class MyActivity extends Activity {
-			myService = this.attach(
-				app.services.observe<MyService>(
-					"Test.MyService",
-					(svc) => svc && this.update(),
-				),
-			);
-			update() {
-				// note: this.myService may not actually be set yet here
+		app.services.add(svc1);
+		let other = new OtherService();
+		ManagedObject.observe(other, ["myService"], () => {
+			other.myService?.listen(() => {
 				t.count("update");
-			}
-		}
-		let act = new MyActivity();
-		expect(act.myService).toHaveProperty("service").toBe(svc);
-		svc.emitChange();
-		t.expectCount("update").toBe(2);
-		act.unlink();
-		expect(act.myService).toHaveProperty("service").toBeUndefined();
-		expect(act.myService.isUnlinked()).toBe(true);
-		svc.unlink();
+			});
+		});
+		app.services.add(other);
+		svc1.emitChange();
+		let svc2 = new MyService();
+		app.services.add(svc2);
+		svc2.emitChange();
+		svc2.emitChange();
+		t.expectCount("update").toBe(3);
+		svc2.unlink();
+		other.unlink();
 	});
 });

--- a/packages/frame-core/test/tests/base/managedlist.ts
+++ b/packages/frame-core/test/tests/base/managedlist.ts
@@ -1,10 +1,10 @@
-import {
-	ManagedObject,
-	ManagedList,
-	ManagedEvent,
-	bound,
-} from "../../../dist/index.js";
 import { describe, expect, test } from "@desk-framework/frame-test";
+import {
+	ManagedEvent,
+	ManagedList,
+	ManagedObject,
+	bind,
+} from "../../../dist/index.js";
 
 describe("ManagedList", () => {
 	/** Class used throughout tests below */
@@ -820,7 +820,7 @@ describe("ManagedList", () => {
 			class MyObject extends ManagedObject {
 				constructor() {
 					super();
-					bound("list.count").bindTo(this, "boundCount");
+					bind("list.count").bindTo(this, "boundCount");
 				}
 				boundCount?: number;
 			}

--- a/packages/frame-core/test/tests/ui/button.ts
+++ b/packages/frame-core/test/tests/ui/button.ts
@@ -143,4 +143,27 @@ describe("UIButton", (scope) => {
 		await t.sleep(2);
 		expect(app.navigation.pageId).toBe("foo");
 	});
+
+	test("Back button navigation", async (t) => {
+		let MyButton = ui.button({
+			label: "back",
+			onClick: "NavigateBack",
+		});
+		class MyActivity extends Activity {
+			constructor() {
+				super({ renderPlacement: { mode: "page" } });
+			}
+			protected override createView() {
+				return new MyButton();
+			}
+		}
+		app.addActivity(new MyActivity(), true);
+		app.navigate("foo");
+		await t.expectNavAsync(50, "foo");
+		app.navigate("bar");
+		await t.expectNavAsync(50, "bar");
+		let elt = (await t.expectOutputAsync(100, { text: "back" })).getSingle();
+		elt.click();
+		await t.expectNavAsync(50, "foo");
+	});
 });

--- a/packages/frame-core/test/tests/ui/conditional.ts
+++ b/packages/frame-core/test/tests/ui/conditional.ts
@@ -5,10 +5,10 @@ import {
 	useTestContext,
 } from "@desk-framework/frame-test";
 import {
+	$view,
 	ManagedObject,
 	UICell,
 	ViewComposite,
-	bound,
 	ui,
 } from "../../../dist/index.js";
 
@@ -45,7 +45,7 @@ describe("UIConditionalView", () => {
 			{ condition: false },
 			ui.cell(
 				ui.conditional(
-					{ state: bound("condition") },
+					{ state: $view.boolean("condition") },
 					// label should only be rendered when condition is true
 					ui.label("foo"),
 				),

--- a/packages/frame-core/test/tests/ui/form.ts
+++ b/packages/frame-core/test/tests/ui/form.ts
@@ -5,6 +5,8 @@ import {
 	useTestContext,
 } from "@desk-framework/frame-test";
 import {
+	$activity,
+	$view,
 	Activity,
 	ManagedEvent,
 	UIFormContext,
@@ -13,7 +15,6 @@ import {
 	UITextField,
 	ViewComposite,
 	app,
-	bound,
 	ui,
 } from "../../../dist/index.js";
 
@@ -166,7 +167,7 @@ describe("UIFormContext", () => {
 		const MyComp = ViewComposite.define(
 			{ formContext: undefined as UIFormContext | undefined },
 			ui.row(
-				ui.label(bound("formContext.errors.foo")),
+				ui.label($view.bind("formContext.errors.foo")),
 				ui.textField({ formField: "foo" }),
 			),
 		);
@@ -204,12 +205,12 @@ describe("UIFormContext", () => {
 			ui.row(
 				ui.use(
 					FormContainer,
-					{ formContext: bound("form1") },
+					{ formContext: $activity.bind("form1") },
 					ui.textField({ formField: "text" }),
 				),
 				ui.use(
 					FormContainer,
-					{ formContext: bound("form2") },
+					{ formContext: $activity.bind("form2") },
 					ui.textField({ formField: "text" }),
 				),
 			),

--- a/packages/frame-core/test/tests/ui/jsx.tsx
+++ b/packages/frame-core/test/tests/ui/jsx.tsx
@@ -5,6 +5,7 @@ import {
 	useTestContext,
 } from "@desk-framework/frame-test";
 import {
+	$view,
 	BindingOrValue,
 	LazyString,
 	StringConvertible,
@@ -14,7 +15,6 @@ import {
 	UILabel,
 	ViewComposite,
 	app,
-	bound,
 	strf,
 	ui,
 } from "../../../dist/index.js";
@@ -187,7 +187,7 @@ describe("JSX", () => {
 			}
 			foo: number = 0;
 			override defineView() {
-				return <label>{bound("foo")}</label>;
+				return <label>{$view.bind("foo")}</label>;
 			}
 		}
 		useTestContext((options) => {
@@ -236,10 +236,10 @@ describe("JSX", () => {
 		const MyView = ViewComposite.define(
 			{ foo: 0, bar: undefined as any },
 			<row>
-				<label>foo='{bound("foo")}'</label>
+				<label>foo='{$view.bind("foo")}'</label>
 				<label>bar='%[bar.foo]'</label>
 				<label>baz='%[baz=bar.baz:uc]'</label>
-				<label>nope_bound='{bound("nope", "Nothing")}'</label>
+				<label>nope_bound='{$view.bind("nope", "Nothing")}'</label>
 			</row>,
 		);
 		useTestContext((options) => {

--- a/packages/frame-core/test/tests/ui/list.ts
+++ b/packages/frame-core/test/tests/ui/list.ts
@@ -1,18 +1,19 @@
 import {
-	bound,
+	describe,
+	expect,
+	test,
+	useTestContext,
+} from "@desk-framework/frame-test";
+import {
+	$list,
 	ManagedList,
 	ManagedObject,
 	UILabel,
 	UIListView,
 	UIRow,
+	bind,
 	ui,
 } from "../../../dist/index.js";
-import {
-	describe,
-	test,
-	expect,
-	useTestContext,
-} from "@desk-framework/frame-test";
 
 describe("UIListView", (scope) => {
 	scope.beforeEach(() => {
@@ -70,7 +71,11 @@ describe("UIListView", (scope) => {
 		let list = new ManagedList(...getObjects());
 
 		t.log("Creating instance");
-		let MyList = ui.list({ items: list }, ui.label(bound("item.name")), UIRow);
+		let MyList = ui.list(
+			{ items: list },
+			ui.label($list.string("item.name")),
+			UIRow,
+		);
 		let instance = new MyList();
 
 		t.log("Rendering");
@@ -90,8 +95,8 @@ describe("UIListView", (scope) => {
 	test("List of labels from bound array, rendered", async (t) => {
 		t.log("Creating instance");
 		let MyList = ui.list(
-			{ items: bound("array") },
-			ui.label(bound("item")),
+			{ items: bind("array") },
+			ui.label($list.bind("item")),
 			UIRow,
 		);
 		class ArrayProvider extends ManagedObject {
@@ -112,7 +117,11 @@ describe("UIListView", (scope) => {
 		let list = new ManagedList(a, b, c);
 
 		t.log("Creating instance");
-		let MyList = ui.list({ items: list }, ui.label(bound("item.name")), UIRow);
+		let MyList = ui.list(
+			{ items: list },
+			ui.label($list.string("item.name")),
+			UIRow,
+		);
 		let instance = new MyList();
 
 		t.log("Rendering");
@@ -132,7 +141,7 @@ describe("UIListView", (scope) => {
 		let Preset = ui.row(
 			ui.list(
 				{ items: new ManagedList(...getObjects()) },
-				ui.label({ text: bound("item.name"), onClick: "Foo" }),
+				ui.label({ text: $list.string("item.name"), onClick: "Foo" }),
 				UIRow,
 			),
 		);
@@ -164,7 +173,7 @@ describe("UIListView", (scope) => {
 		t.log("Creating instance");
 		let MyList = ui.list(
 			{ items: new ManagedList(...getObjects()) },
-			ui.label(bound("item.name")),
+			ui.label($list.string("item.name")),
 			UIRow,
 			ui.label("end"),
 		);
@@ -185,7 +194,7 @@ describe("UIListView", (scope) => {
 		t.log("Creating instance");
 		let MyList = ui.list(
 			{ items: new ManagedList(...getObjects()), maxItems: 2 },
-			ui.label(bound("item.name")),
+			ui.label($list.string("item.name")),
 			UIRow,
 		);
 		let instance = new MyList();
@@ -220,7 +229,7 @@ describe("UIListView", (scope) => {
 	test("Get indices for components", async (t) => {
 		let Preset = ui.list(
 			{ items: new ManagedList(...getObjects()) },
-			ui.label({ text: bound("item.name"), allowFocus: true }),
+			ui.label({ text: $list.string("item.name"), allowFocus: true }),
 		);
 		let list = new Preset();
 		t.render(list);
@@ -236,7 +245,7 @@ describe("UIListView", (scope) => {
 			ui.button("button"),
 			ui.list(
 				{ items: new ManagedList(...getObjects()) },
-				ui.label({ text: bound("item.name"), allowFocus: true }),
+				ui.label({ text: $list.string("item.name"), allowFocus: true }),
 				ui.cell({ allowKeyboardFocus: true, accessibleRole: "list" }),
 			),
 		);
@@ -261,7 +270,7 @@ describe("UIListView", (scope) => {
 		let Preset = ui.list(
 			{ items: new ManagedList(...getObjects()) },
 			ui.label({
-				text: bound("item.name"),
+				text: $list.string("item.name"),
 				allowFocus: true,
 				onArrowDownKeyPress: "FocusNext",
 				onArrowUpKeyPress: "FocusPrevious",

--- a/packages/frame-core/test/tests/ui/viewrender.ts
+++ b/packages/frame-core/test/tests/ui/viewrender.ts
@@ -6,6 +6,7 @@ import {
 	useTestContext,
 } from "@desk-framework/frame-test";
 import {
+	$view,
 	Activity,
 	ManagedEvent,
 	StringConvertible,
@@ -14,7 +15,7 @@ import {
 	UIViewRenderer,
 	ViewComposite,
 	app,
-	bound,
+	bind,
 	ui,
 } from "../../../dist/index.js";
 
@@ -64,12 +65,12 @@ describe("UIViewRenderer", (scope) => {
 	test("Set view using view composite, and render", async (t) => {
 		const CompView = ViewComposite.define(
 			{ text: StringConvertible.EMPTY },
-			ui.label(bound("text")),
+			ui.label($view.string("text")),
 		);
 		const Preset = ui.use(CompView, { text: "foo" });
 		class MyActivity extends Activity {
 			protected override createView() {
-				return new (ui.page(ui.renderView({ view: bound("vc") })))();
+				return new (ui.page(ui.renderView({ view: bind("vc") })))();
 			}
 			vc = this.attach(new Preset());
 		}
@@ -103,7 +104,7 @@ describe("UIViewRenderer", (scope) => {
 				const ViewBody = ui.page(
 					ui.cell(
 						{ accessibleLabel: "outer" },
-						ui.renderView({ view: bound("second.view") }),
+						ui.renderView({ view: bind("second.view") }),
 					),
 				);
 				return new ViewBody();

--- a/packages/frame-core/test/tsconfig.json
+++ b/packages/frame-core/test/tsconfig.json
@@ -10,7 +10,7 @@
 		"importHelpers": true,
 		"module": "esnext",
 		"moduleResolution": "node",
-		"target": "esnext",
+		"target": "ES2022",
 		"lib": ["dom", "esnext"],
 		"jsx": "react",
 		"jsxFactory": "ui.jsx",

--- a/packages/frame-test/src/Assertion.ts
+++ b/packages/frame-test/src/Assertion.ts
@@ -443,8 +443,8 @@ export class Assertion<T> {
 		}
 		try {
 			await this.value.apply(undefined, args);
-		} catch {
-			return new Assertion(undefined, "[function threw error async]");
+		} catch (err) {
+			return new Assertion(err, "[Caught error async]");
 		}
 		throw Error(msg[ASSERT.toThrowError](this.name + " (async)"));
 	}

--- a/packages/frame-test/src/style/TestDialog.ts
+++ b/packages/frame-test/src/style/TestDialog.ts
@@ -1,10 +1,10 @@
 import {
+	$view,
 	RenderContext,
 	UITheme,
 	View,
 	ViewComposite,
 	app,
-	bound,
 	ui,
 } from "@desk-framework/frame-core";
 
@@ -20,7 +20,7 @@ export class TestDialog
 	protected override createView() {
 		return new (ui.cell(
 			ui.renderView({
-				view: bound("dialogView"),
+				view: $view.bind("dialogView"),
 				onViewUnlinked: "DialogViewUnlinked",
 			}),
 		))();

--- a/packages/frame-test/test/tests/app.ts
+++ b/packages/frame-test/test/tests/app.ts
@@ -1,11 +1,12 @@
 import {
+	$activity,
+	$view,
 	Activity,
 	StringConvertible,
 	UITextField,
 	ViewComposite,
 	ViewEvent,
 	app,
-	bound,
 	ui,
 } from "@desk-framework/frame-core";
 import { describe, expect, test, useTestContext } from "../../dist/index.js";
@@ -15,7 +16,7 @@ class CountActivity extends Activity {
 	protected override createView() {
 		return new (ui.page(
 			ui.cell(
-				ui.textField({ value: bound("count"), onInput: "SetCount" }),
+				ui.textField({ value: $activity.string("count"), onInput: "SetCount" }),
 				ui.button("+", "CountUp"),
 			),
 		))();
@@ -45,7 +46,7 @@ describe("App test", (scope) => {
 	test("Single view is rendered", async (t) => {
 		const MyView = ViewComposite.define(
 			{ title: StringConvertible.EMPTY },
-			ui.label(bound("title")),
+			ui.label($view.bind("title")),
 		);
 		let Preset = ui.use(MyView, { title: "TEST" });
 		let myView = new Preset();

--- a/packages/frame-web/src/style/Dialog.ts
+++ b/packages/frame-web/src/style/Dialog.ts
@@ -1,10 +1,10 @@
 import {
+	$view,
 	RenderContext,
 	UITheme,
 	View,
 	ViewComposite,
 	app,
-	bound,
 	ui,
 } from "@desk-framework/frame-core";
 
@@ -49,7 +49,7 @@ export class Dialog extends ViewComposite implements UITheme.DialogController {
 				style: Dialog.styles.containerStyle,
 			},
 			ui.renderView({
-				view: bound("dialogView"),
+				view: $view.bind("dialogView"),
 				onViewUnlinked: "DialogViewUnlinked",
 			}),
 		))();

--- a/packages/frame-web/test/esbuild-es2015/src/count/NumberCount.tsx
+++ b/packages/frame-web/test/esbuild-es2015/src/count/NumberCount.tsx
@@ -1,6 +1,6 @@
 import {
+	$view,
 	ViewComposite,
-	bound,
 	ui,
 } from "../../../../lib/desk-framework-web.es2015.esm.min";
 
@@ -8,6 +8,6 @@ export default ViewComposite.define(
 	{ count: 0 },
 	<column>
 		<label>Count:</label>
-		<label style={{ bold: true, fontSize: 36 }}>{bound.number("count")}</label>
+		<label style={{ bold: true, fontSize: 36 }}>{$view.number("count")}</label>
 	</column>,
 );

--- a/packages/frame-web/test/esbuild-es2015/src/count/body.tsx
+++ b/packages/frame-web/test/esbuild-es2015/src/count/body.tsx
@@ -1,9 +1,12 @@
-import { bound, ui } from "../../../../lib/desk-framework-web.es2015.esm.min";
+import {
+	$activity,
+	ui,
+} from "../../../../lib/desk-framework-web.es2015.esm.min";
 import NumberCount from "./NumberCount";
 
 export default (
 	<column distribute="center">
-		<NumberCount count={bound.number("count")} />
+		<NumberCount count={$activity.number("count")} />
 		<spacer height={32} />
 		<animate showAnimation={ui.animation.FADE_IN_DOWN}>
 			<row align="center">

--- a/packages/frame-web/test/esbuild-es2015/src/main/_themeToggle.tsx
+++ b/packages/frame-web/test/esbuild-es2015/src/main/_themeToggle.tsx
@@ -1,6 +1,6 @@
 import {
 	UIStyle,
-	bound,
+	$activity,
 	ui,
 } from "../../../../lib/desk-framework-web.es2015.esm.min";
 
@@ -33,14 +33,14 @@ export default (
 				<button
 					label="Light"
 					value="light"
-					pressed={bound("selectedTheme").matches("light")}
+					pressed={$activity.bind("selectedTheme").matches("light")}
 					style={ToggleButtonStyle}
 					onPress="+SetTheme"
 				/>
 				<button
 					label="Dark"
 					value="dark"
-					pressed={bound("selectedTheme").matches("dark")}
+					pressed={$activity.bind("selectedTheme").matches("dark")}
 					style={ToggleButtonStyle}
 					onPress="+SetTheme"
 				/>

--- a/packages/frame-web/test/esbuild-es2015/src/main/body.tsx
+++ b/packages/frame-web/test/esbuild-es2015/src/main/body.tsx
@@ -1,4 +1,4 @@
-import { bound, ui } from "../../../../lib/desk-framework-web.es2015.esm.min";
+import { bind, ui } from "../../../../lib/desk-framework-web.es2015.esm.min";
 import _themeToggle from "./_themeToggle";
 
 export default (
@@ -10,7 +10,7 @@ export default (
 				{_themeToggle}
 			</row>
 			<cell>
-				<render view={bound("countActivity.view")} />
+				<render view={bind("countActivity.view")} />
 			</cell>
 		</scroll>
 	</mount>

--- a/packages/frame-web/test/esbuild/src/counter.tsx
+++ b/packages/frame-web/test/esbuild/src/counter.tsx
@@ -2,14 +2,14 @@ import { Activity, ui } from "../../../dist";
 
 const ViewBody = (
 	<mount page>
-		<cell>
+		<column>
 			<label style={{ bold: true, fontSize: 36 }}>Count: %[count]</label>
 			<spacer height={32} />
 			<row align="center">
 				<button onClick="CountDown">Down</button>
 				<button onClick="CountUp">Up</button>
 			</row>
-		</cell>
+		</column>
 	</mount>
 );
 

--- a/packages/frame-web/test/esm-js/site/ListActivity.js
+++ b/packages/frame-web/test/esm-js/site/ListActivity.js
@@ -1,12 +1,14 @@
 import {
+	$activity,
+	$list,
+	$view,
 	Activity,
 	ManagedList,
 	ManagedRecord,
+	StringConvertible,
 	UIFormContext,
 	UITextField,
 	ViewComposite,
-	app,
-	bound,
 	ui,
 } from "./lib/desk-framework-web.es2018.esm.min.js";
 
@@ -15,13 +17,13 @@ class ListItem extends ManagedRecord {
 }
 
 const ListItemView = ViewComposite.define(
-	{ text: undefined, selected: false },
+	{ text: StringConvertible.EMPTY, selected: false },
 	ui.cell(
 		{
 			background: ui.color.BACKGROUND,
 			effect: ui.effect.SHADOW,
 			borderRadius: 4,
-			style: bound
+			style: $view
 				.boolean("selected")
 				.select(
 					{ borderThickness: 1, borderColor: ui.color.TEXT },
@@ -34,9 +36,9 @@ const ListItemView = ViewComposite.define(
 			onArrowUpKeyPress: "+FocusPrevious",
 		},
 		ui.row(
-			ui.label({ text: bound("text"), style: { grow: 1 } }),
+			ui.label({ text: $view.string("text"), style: { grow: 1 } }),
 			ui.button({
-				hidden: bound.not("selected"),
+				hidden: $view.not("selected"),
 				icon: ui.icon.CLOSE,
 				style: ui.style.BUTTON_ICON,
 				onClick: "RemoveItem",
@@ -65,10 +67,10 @@ const page = ui.page(
 			),
 			ui.spacer(0, 8),
 			ui.list(
-				{ items: bound.list("items") },
+				{ items: $activity.list("items") },
 				ui.use(ListItemView, {
-					text: bound.string("item.text"),
-					selected: bound("selectedItem").equals("item"),
+					text: $list.string("item.text"),
+					selected: $activity.bind("selectedItem").equals($list.bind("item")),
 				}),
 				ui.column({ spacing: 8, accessibleRole: "list" }),
 			),
@@ -93,7 +95,7 @@ export class ListActivity extends Activity {
 			this.items.first(),
 		);
 		this.formContext.clear();
-		this.findViewContent(UITextField)[0].requestFocus();
+		this.findViewContent(UITextField)[0]?.requestFocus();
 	}
 
 	onSelectItem(e) {

--- a/packages/frame-web/test/esm-js/site/jsconfig.json
+++ b/packages/frame-web/test/esm-js/site/jsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"checkJs": true,
 		"strict": true,
 		"noImplicitAny": true,
 		"noUnusedLocals": true,

--- a/packages/frame-web/test/esm/src/counter.tsx
+++ b/packages/frame-web/test/esm/src/counter.tsx
@@ -2,14 +2,14 @@ import { Activity, ui } from "../lib/desk-framework-web.es2018.esm.min.js";
 
 const ViewBody = (
 	<mount page>
-		<cell>
+		<column>
 			<label style={{ bold: true, fontSize: 36 }}>Count: %[count]</label>
 			<spacer height={32} />
 			<row align="center">
 				<button onClick="CountDown">Down</button>
 				<button onClick="CountUp">Up</button>
 			</row>
-		</cell>
+		</column>
 	</mount>
 );
 

--- a/packages/frame-web/test/iife/test-iife.js
+++ b/packages/frame-web/test/iife/test-iife.js
@@ -1,9 +1,9 @@
-const { app, ui, bound } = desk;
+const { app, ui, bind } = desk;
 
 (function () {
 	const ViewBody = ui.page(
-		ui.cell(
-			ui.label(bound.strf("Count: %n", "count"), {
+		ui.column(
+			ui.label(bind.strf("Count: %n", bind("count")), {
 				bold: true,
 				fontSize: 36,
 			}),

--- a/packages/frame-web/test/parcel/src/counter.tsx
+++ b/packages/frame-web/test/parcel/src/counter.tsx
@@ -2,14 +2,14 @@ import { Activity, ui } from "@desk-framework/frame-core";
 
 const ViewBody = (
 	<mount page>
-		<cell>
+		<column>
 			<label style={{ bold: true, fontSize: 36 }}>Count: %[count]</label>
 			<spacer height={32} />
 			<row align="center">
 				<button onClick="CountDown">Down</button>
 				<button onClick="CountUp">Up</button>
 			</row>
-		</cell>
+		</column>
 	</mount>
 );
 

--- a/packages/frame-web/test/perf/src/perf.tsx
+++ b/packages/frame-web/test/perf/src/perf.tsx
@@ -1,4 +1,4 @@
-import { app, AsyncTaskQueue, bound, Activity, ui } from "../../../dist";
+import { app, AsyncTaskQueue, Activity, ui, $activity } from "../../../dist";
 
 const MAX = 10000;
 
@@ -12,7 +12,7 @@ const ViewBody = (
 			<row layout={{ padding: { x: 40, y: 16 } }}>
 				<label style={ui.style.LABEL_TITLE}>Perf test</label>
 			</row>
-			<list items={bound("items")}>
+			<list items={$activity.bind("items")}>
 				<row height={48}>
 					<label
 						icon={ui.icon.CHEVRON_NEXT}

--- a/packages/frame-web/test/webpack/src/counter.js
+++ b/packages/frame-web/test/webpack/src/counter.js
@@ -1,8 +1,11 @@
-import { Activity, app, bound, ui } from "@desk-framework/frame-core";
+import { Activity, app, bind, ui } from "@desk-framework/frame-core";
 
 const ViewBody = ui.page(
-	ui.cell(
-		ui.label(bound.strf("Count: %i", "count"), { bold: true, fontSize: 36 }),
+	ui.column(
+		ui.label(bind.strf("Count: %i", bind("count")), {
+			bold: true,
+			fontSize: 36,
+		}),
 		ui.spacer({ height: 32 }),
 		ui.row(
 			{ align: "center" },


### PR DESCRIPTION
This PR includes a refactoring of the low level implementation for bindings.

It also adds a feature to bind to specific types of objects by checking for the presence of a property (using a string or symbol). This enables binding 'source' objects including `$activity` and `$viewport`, which have methods for creating bindings that only use these respective sources, i.e. `Activity` objects and `app.viewport`.