### PR TITLE
Fix: don't set button pressed state to false

### DIFF
--- a/packages/frame-core/src/ui/controls/UIButton.ts
+++ b/packages/frame-core/src/ui/controls/UIButton.ts
@@ -107,7 +107,7 @@ export class UIButton extends UIComponent {
 	 * The current visual selection state
 	 * - This property is not set automatically. It can be set manually, or bound using {@link Binding.matches()} to select and deselect the button based on the current value of a property.
 	 */
-	pressed = false;
+	pressed?: boolean = undefined;
 
 	/**
 	 * An option value that this button represents, if any


### PR DESCRIPTION
The `pressed = false` state made screen readers announce all buttons as toggle buttons. The correct value should be undefined by default. 